### PR TITLE
Added support for joining to virtual tables

### DIFF
--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -242,9 +242,15 @@ class MongoToKnex {
                             innerJoinOn = `${reference.config.tableNameAs}.${reference.config.joinToForeign || 'id'}`;
                         }
 
-                        const innerQB = this
+                        let query = this
                             .select(`${reference.config.joinTable}.${reference.config.joinFrom}`)
-                            .from(`${reference.config.joinTable}`)
+                            .from(`${reference.config.joinTable}`);
+
+                        if (reference.config.virtualTable) {
+                            query = query.with(reference.config.tableName, reference.config.virtualTableDefinition);
+                        }
+
+                        const innerQB = query
                             .innerJoin(innerJoinValue, function () {
                                 this.on(innerJoinOn, '=', `${reference.config.joinTable}.${reference.config.joinTo}`);
 
@@ -320,9 +326,15 @@ class MongoToKnex {
                             innerJoinOn = `${reference.config.tableNameAs}.${reference.config.joinFrom}`;
                         }
 
-                        const innerQB = this
+                        let query = this
                             .select(`${tableName}.id`)
-                            .from(`${tableName}`)
+                            .from(`${tableName}`);
+
+                        if (reference.config.virtualTable) {
+                            query = query.with(reference.config.tableName, reference.config.virtualTableDefinition);
+                        }
+
+                        const innerQB = query
                             .leftJoin(innerJoinValue, function () {
                                 this.on(innerJoinOn, '=', `${tableName}.id`);
 

--- a/packages/mongo-knex/test/integration/relations.test.js
+++ b/packages/mongo-knex/test/integration/relations.test.js
@@ -30,6 +30,22 @@ const makeQuery = (mongoJSON) => {
                 type: 'oneToOne',
                 joinFrom: 'post_id'
             },
+            views: {
+                tableName: 'views',
+                type: 'oneToOne',
+                joinFrom: 'post_id',
+                virtualTable: true,
+                virtualTableDefinition: knex.raw(`
+                    SELECT
+                        posts_view_events.post_id,
+                        SUM(posts_view_events.count) as total
+                    FROM posts
+                    JOIN posts_view_events
+                        ON posts.id = posts_view_events.post_id
+                    GROUP BY
+                        posts.id
+                `)
+            },
             comments: {
                 tableName: 'comments',
                 type: 'manyToMany',
@@ -54,6 +70,25 @@ describe('Relations', function () {
         await utils.db.setup()();
     });
     after(utils.db.teardown());
+
+    describe('Virtual Table', function () {
+        it('Should allow relations with virtual tables', function () {
+            const mongoJSON = {
+                'views.total': {
+                    $gt: 10
+                }
+            };
+
+            const query = makeQuery(mongoJSON);
+
+            return query
+                .select()
+                .then((result) => {
+                    result.should.be.an.Array().with.lengthOf(2);
+                    result.should.matchIds([1, 2]);
+                });
+        });
+    });
 
     describe('Many-to-Many', function () {
         before(utils.db.init('many-to-many'));

--- a/packages/mongo-knex/test/integration/suite1/fixtures/base.json
+++ b/packages/mongo-knex/test/integration/suite1/fixtures/base.json
@@ -154,5 +154,61 @@
             "meta_description": null,
             "like_count": 42
         }
+    ],
+    "posts_view_events": [
+        {
+            "id": 1,
+            "post_id": 1,
+            "count": 2,
+            "date": "2021-01-01"
+        },
+        {
+            "id": 2,
+            "post_id": 2,
+            "count": 4,
+            "date": "2021-01-01"
+        },
+        {
+            "id": 3,
+            "post_id": 3,
+            "count": 0,
+            "date": "2021-01-01"
+        },
+        {
+            "id": 4,
+            "post_id": 1,
+            "count": 6,
+            "date": "2021-01-02"
+        },
+        {
+            "id": 5,
+            "post_id": 2,
+            "count": 3,
+            "date": "2021-01-02"
+        },
+        {
+            "id": 6,
+            "post_id": 3,
+            "count": 0,
+            "date": "2021-01-02"
+        },
+        {
+            "id": 7,
+            "post_id": 1,
+            "count": 5,
+            "date": "2021-01-03"
+        },
+        {
+            "id": 8,
+            "post_id": 2,
+            "count": 7,
+            "date": "2021-01-03"
+        },
+        {
+            "id": 9,
+            "post_id": 3,
+            "count": 10,
+            "date": "2021-01-03"
+        }
     ]
 }

--- a/packages/mongo-knex/test/integration/suite1/schema.js
+++ b/packages/mongo-knex/test/integration/suite1/schema.js
@@ -2,6 +2,7 @@ const Promise = require('bluebird');
 const TABLES = [
     'posts_comments',
     'comments',
+    'posts_view_events',
     'posts_tags',
     'posts_authors',
     'posts_meta',
@@ -53,6 +54,12 @@ module.exports.up = function (knex) {
             table.integer('post_id').unsigned().references('posts.id');
             table.integer('author_id').unsigned().references('users.id');
             table.integer('sort_order').defaultTo(0);
+        }))
+        .then(() => knex.schema.createTable('posts_view_events', (table) => {
+            table.increments('id').primary();
+            table.integer('post_id').unsigned().references('posts.id');
+            table.integer('count');
+            table.dateTime('date');
         }))
         .then(() => knex.schema.createTable('comments', (table) => {
             table.increments('id').primary();


### PR DESCRIPTION
⚠️ blocked to be merged until MySQL 5 has been dropped in Ghost

refs https://github.com/TryGhost/Team/issues/944

Currently mongo-knex does not allow setting up relations which use an
aggregate function, e.g. filtering based on the SUM of a related column.

I initially looked at adding a new relation type like
`oneToOneAggregate` but this proved to require large changes to the
codebase, with a big increase in complexity.

The approach here is to allow consumers of the library to have the
ability to define a virtual table as a knex query, which allows for more
complex relations, including aggregates, or joins over multiple tables.