### PR TITLE
fix: correct mongo-knex regexp resolution with relations

### DIFF
--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -317,7 +317,25 @@ class MongoToKnex {
                                 statementValue = !_.isArray(statement.value) ? [statement.value] : statement.value;
                             }
 
-                            innerQB[statement.whereType](statementColumn, statementOp, statementValue);
+                            if ([compOps.$regex, compOps.$not].indexOf(statementOp) === -1) {
+                                innerQB[statement.whereType](statementColumn, statementOp, statementValue);
+                            } else {
+                                // knex ILike won't work because of `COLLATION 'utf8_bin'`
+                                // e.g. COLLATION 'utf8_bin' is not valid for CHARACTER SET 'latin1'
+                                // for MySQL, case-sensitive LIKEs won't work without casting to BINARY
+                                // the behavior aligns with commit 7b8798a6fa7870c98648cae5a494eb761638a208
+                                // for an actual database agnostic solution, we need to rework everything around this
+
+                                let whereType = statement.whereType;
+                                const {source, ignoreCase} = processRegExp(statementValue);
+                                if (!ignoreCase) {
+                                    innerQB[whereType](statementColumn, statementOp, source);
+                                } else {
+                                    whereType += 'Raw';
+                                    debug(`(buildComparison) whereType: ${whereType}, statement: ${statement}, op: ${statement.operator}, comp: ${statementOp}, value: ${source} (REGEX/i)`);
+                                    innerQB[whereType](`lower(??) ${statementOp} ?`, [statementColumn, source]);
+                                }
+                            }
                         });
 
                         if (debugExtended.enabled) {

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -334,6 +334,22 @@ describe('Relations', function () {
             .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` in (\'fred\'))');
     });
 
+    it('should be able to perform a regexp query on a many-to-many relation', function () {
+        runQuery({'tags.slug': {$regex: /foo/}})
+            .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` like \'%foo%\')');
+
+        runQuery({'tags.slug': {$regex: /foo/i}})
+            .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where lower(`tags`.`slug`) like \'%foo%\')');
+    });
+
+    it('should be able to perform a negate regexp query on a many-to-many relation', function () {
+        runQuery({'tags.slug': {$not: /bar/}})
+            .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` not like \'%bar%\')');
+
+        runQuery({'tags.slug': {$not: /bar/i}})
+            .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where lower(`tags`.`slug`) not like \'%bar%\')');
+    });
+
     // This case doesn't work
     it.skip('should be able to perform a query on a many-to-many join table alone', function () {
         runQuery({'posts_tags.sort_order': 0});
@@ -366,6 +382,9 @@ describe('Relations', function () {
 
 describe('RegExp/Like queries', function () {
     it('are well behaved', function () {
+        runQuery({title: {$regex: /bar/}})
+            .should.eql('select * from `posts` where `posts`.`title` like \'%bar%\'');
+
         runQuery({title: {$regex: /'/i}})
             .should.eql('select * from `posts` where lower(`posts`.`title`) like \'%\\\'%\'');
 


### PR DESCRIPTION
This solves issue with relation regexp filtering.
`http://localhost:2368/ghost/api/v4/content/posts/?key=redacted&filter=tag:~'foo'`

```
{"errors":[{"message":"Internal server error, cannot list posts.","context":"select count(distinct posts.id) as aggregate from `posts` where (`posts`.`status` = 'published' and (`posts`.`type` = 'post' and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` like {}))) - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')))' at line 1","type":"InternalServerError","details":null,"property":null,"help":null,"code":"ER_PARSE_ERROR","id":"redacted","ghostErrorCode":null}]}
```

I thought of using Knex Like and ILike but for now it won't work because of `COLLATION 'utf8_bin'`.
`COLLATION 'utf8_bin' is not valid for CHARACTER SET 'latin1'`

The behavior aligns with commit 7b8798a6fa7870c98648cae5a494eb761638a208.
MySQL case-sensitive LIKEs also won't work without casting to BINARY.
For an actual database agnostic solution, we need to rework everything around this.

I tried some SQL Injection test cases but NQL parser works well :laughing: 