### PR TITLE
Added support for null checks in relations (mongo-knex)

### DIFF
--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -263,9 +263,11 @@ class MongoToKnex {
                     const comp = negateGroup
                         ? compOps.$nin
                         : compOps.$in;
+                    
+                    const whereType = ['whereNull', 'whereNotNull'].includes(reference.whereType) ? 'andWhere' : (['orWhereNull', 'orWhereNotNull'].includes(reference.whereType) ? 'orWhere' : reference.whereType);
 
                     // CASE: WHERE resource.id (IN | NOT IN) (SELECT ...)
-                    qb[reference.whereType](`${this.tableName}.id`, comp, function () {
+                    qb[whereType](`${this.tableName}.id`, comp, function () {
                         const joinFilterStatements = groupedRelations[key].joinFilterStatements;
 
                         let innerJoinValue = reference.config.tableName;
@@ -277,10 +279,11 @@ class MongoToKnex {
                             innerJoinOn = `${reference.config.tableNameAs}.${reference.config.joinToForeign || 'id'}`;
                         }
 
+                        const joinType = reference.config.joinType || 'innerJoin';
+
                         const innerQB = this
                             .select(`${reference.config.joinTable}.${reference.config.joinFrom}`)
-                            .from(`${reference.config.joinTable}`)
-                            .innerJoin(innerJoinValue, function () {
+                            .from(`${reference.config.joinTable}`)[joinType](innerJoinValue, function () {
                                 this.on(innerJoinOn, '=', `${reference.config.joinTable}.${reference.config.joinTo}`);
 
                                 // CASE: when applying AND con junction and having multiple groups the filter

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -11,6 +11,14 @@ const runQuery = query => convertor(knex('posts'), query, {
             joinFrom: 'post_id',
             joinTo: 'tag_id'
         },
+        optional_tags: {
+            tableName: 'optional_tags',
+            type: 'manyToMany',
+            joinTable: 'posts_tags',
+            joinFrom: 'post_id',
+            joinTo: 'tag_id',
+            joinType: 'leftJoin'
+        },
         posts_meta: {
             tableName: 'posts_meta',
             type: 'oneToOne',
@@ -332,6 +340,11 @@ describe('Relations', function () {
     it('should be able to perform NULL query on a many-to-many relation', function () {
         runQuery({'tags.slug': null})
             .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` is null)');
+    });
+
+    it('should be able to perform NULL query on a many-to-many relation with left join', function () {
+        runQuery({'optional_tags.slug': null})
+            .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` left join `optional_tags` on `optional_tags`.`id` = `posts_tags`.`tag_id` where `optional_tags`.`slug` is null)');
     });
 
     it('should be able to perform a negated query on a many-to-many relation (works but is weird)', function () {

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -329,6 +329,11 @@ describe('Relations', function () {
             .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = \'fred\')');
     });
 
+    it('should be able to perform NULL query on a many-to-many relation', function () {
+        runQuery({'tags.slug': null})
+            .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` is null)');
+    });
+
     it('should be able to perform a negated query on a many-to-many relation (works but is weird)', function () {
         runQuery({'tags.slug': {$ne: 'fred'}})
             .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` in (\'fred\'))');


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2160

For checking if a relation is null, we need these changes.
Support for setting the join type to 'leftJoin' in the config of relations for optional relations
Properly handle 'null' values in relation queries