### PR TITLE
Upgraded `mingo` to 6.4.6

### DIFF
--- a/packages/nql/package.json
+++ b/packages/nql/package.json
@@ -31,6 +31,6 @@
     "@tryghost/mongo-knex": "^0.8.0",
     "@tryghost/mongo-utils": "^0.5.0",
     "@tryghost/nql-lang": "^0.5.0",
-    "mingo": "^2.2.2"
+    "mingo": "^6.4.5"
   }
 }

--- a/packages/nql/test/unit/api.test.js
+++ b/packages/nql/test/unit/api.test.js
@@ -68,6 +68,9 @@ describe('Public API', function () {
     });
 
     it('ensure caching works as expected', function () {
+        // Ensure mingo.Query can be spied on
+        Object.defineProperty(mingo, 'Query', {writable: true, value: mingo.Query});
+
         sandbox.spy(mingo, 'Query');
         sandbox.spy(nqlLang, 'parse');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3350,10 +3350,10 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-mingo@^2.2.2:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/mingo/-/mingo-2.5.3.tgz#bed3db76ca9b2cc29ae1f1ff83e3a8797dc47758"
-  integrity sha512-Wb98QEQ/DaT+xPQFAX08mzM/Zz2eW1UIpKH132gXglakl2SKYBCQFzeiFygS/Hgzc9j9MDDjgouB9W7BMaLyaQ==
+mingo@6.4.5:
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/mingo/-/mingo-6.4.5.tgz#786d6182dcd953c8dc054529d2c3e4497202af0f"
+  integrity sha512-ezEfIWciAJVYjX76SeOFp0TiJnoDFt3ACqF0yNMIsvOP/MVWUzmmQ0AIcwIafsD3TMirLnbvDhIBr8VfHxxIxQ==
 
 minimatch@3.0.5:
   version "3.0.5"


### PR DESCRIPTION
Upgraded `mingo` to 6.4.6 due to older versions not playing nicely with `vite` when bundled up (due to invalid `module` reference in `package.json`)