### PR TITLE
🐛 Fixed escaping of forward slash, percentage and underscore signs

### DIFF
--- a/packages/nql/test/unit/query.test.js
+++ b/packages/nql/test/unit/query.test.js
@@ -17,7 +17,7 @@ describe('NQL -> SQL', function () {
             ]);
 
             query.toJSON().should.eql({name: {$regex: /John O'Nolan/i}});
-            query.querySQL(knex('users')).toQuery().should.eql('select * from `users` where lower(`users`.`name`) like \'%john o\\\'nolan%\'');
+            query.querySQL(knex('users')).toQuery().should.eql('select * from `users` where lower(`users`.`name`) like \'%john o\\\'nolan%\' ESCAPE \'*\'');
 
             query = nql(`name:~'John O\\"Nolan'`);
             query.toJSON().should.eql({name: {$regex: /John O"Nolan/i}});
@@ -28,7 +28,7 @@ describe('NQL -> SQL', function () {
                 {token: 'STRING', matched: '\'John O\\"Nolan\''}
             ]);
 
-            query.querySQL(knex('users')).toQuery().should.eql('select * from `users` where lower(`users`.`name`) like \'%john o\\"nolan%\'');
+            query.querySQL(knex('users')).toQuery().should.eql('select * from `users` where lower(`users`.`name`) like \'%john o\\"nolan%\' ESCAPE \'*\'');
 
             query = nql(`name:~'A\\'B\\"C\\"D\\''`);
             query.toJSON().should.eql({name: {$regex: /A'B"C"D'/i}});
@@ -39,7 +39,7 @@ describe('NQL -> SQL', function () {
                 {token: 'STRING', matched: '\'A\\\'B\\"C\\"D\\\'\''}
             ]);
 
-            query.querySQL(knex('users')).toQuery().should.eql('select * from `users` where lower(`users`.`name`) like \'%a\\\'b\\"c\\"d\\\'%\'');
+            query.querySQL(knex('users')).toQuery().should.eql('select * from `users` where lower(`users`.`name`) like \'%a\\\'b\\"c\\"d\\\'%\' ESCAPE \'*\'');
         });
 
         it('errors for unescaped quotes / injection patterns', function () {
@@ -62,7 +62,7 @@ describe('NQL -> SQL', function () {
             query.toJSON().should.eql({name: {$regex: /';select \* from `settings` where `value` like '/i}});
 
             //SQL still ends up correctly escaped. This is all handled by knex... but having a test feels right
-            query.querySQL(knex('users')).toQuery().should.eql('select * from `users` where lower(`users`.`name`) like \'%\\\';select * from `settings` where `value` like \\\'%\'');
+            query.querySQL(knex('users')).toQuery().should.eql('select * from `users` where lower(`users`.`name`) like \'%\\\';select ** from `settings` where `value` like \\\'%\' ESCAPE \'*\'');
         });
     });
 });


### PR DESCRIPTION
fixes https://github.com/TryGhost/Product/issues/3965

## Context
When we parse and execute a NQL startWith/contains/endWith filter that contains a slash in SQL, the NQL string filter will get converted to a MongoDB query object, which uses a Regex to represent startsWith/contains/endWith filters. If we execute this NQL filter in SQL, this Mongo DB query object will get converted to called knex methods. So the Regex will eventually be converted to a SQL `LIKE` query.

## 1. SQLite: when a startsWith filter string contains `/`
refs https://ghost.slack.com/archives/C02G9E68C/p1695812152570319?thread_ts=1695741311.759409&cid=C02G9E68C

A forward slash is a special Regex character. When converting the NQL string to the MongoDB object, it will get escaped and stored as `\/` in the Regex. **Currently, when we convert the Regex to the `LIKE` query, we don't remove this escaping.**

MySQL seems to ignore this (kinda incorrect).  SQLite doesn't like it, and this breaks queries on SQLite that use slashes.

The solution here is simple: remove the backslash when converting the Regex to LIKE, just like we do with all the other special Regex characters that we currently unescape correctly.

## 2. We don't escape `%` and `_`, which have a special meaning in LIKE queries

![Image](https://github.com/TryGhost/Product/assets/5277847/0c1adf9f-d47b-4eb9-a609-fb5b516497b7)

In the picture above, the query in the end is translated to something ± `LIKE '%simo____%'`, which has a total different meaning in SQL. (`_` means `match any character`) It should be something along the lines of `LIKE '%simo\_\_\_\_%'` As you can see, the results in the background of the screenshot are not correct.

To fix this, we should escape the % and _ characters, as explained in both the MySQL and SQLite documentation pages. A logical candidate for escapes would be to use the backslash character. However, this is not possible because we use binded parameters in Knex (for security considerations we should definitely not remove that), and knex will reescape backslashes for a second time.

```
whereRaw('?? LIKE ?`, ['href', `LIKE '%simo\\_\\_\\_\\_%'`]); // \\ is escaped in JS so the string only contains one backslash!
```
Will eventually send the following query to the server (note this isn't double escaped manually or in the logs):
```
WHERE `href` LIKE '%simo\\_\\_\\_\\_%'
```

To fix this, we can use a different ESCAPE character in both MySQL and SQLite.
```
whereRaw('?? LIKE ? ESCAPE ?`, ['href', `LIKE '%simo*_*_*_*_%'`, '*']); 
```
```
WHERE `href` LIKE '%simo*_*_*_*_%' ESCAPE '*'
```

### This works as expected in MySQL:


![Image](https://github.com/TryGhost/Product/assets/5277847/af6c7e16-20af-437b-b5b0-b3066e77e733)

### And in SQLite too:

![Image](https://github.com/TryGhost/Product/assets/5277847/43ea69f1-b0fc-4670-8072-b78e05f4f8a0)


### Using the escape character in filters also still works if we double escape them (so * = ** in the real query):


![Image](https://github.com/TryGhost/Product/assets/5277847/5335a8b7-3beb-4f72-9258-4adcafc85385)


![Image](https://github.com/TryGhost/Product/assets/5277847/da31e615-ff85-42d3-9d3f-8f4afbbdff05)

### Filtering on a backslash works as expected:

![Image](https://github.com/TryGhost/Product/assets/5277847/23a19e25-2081-476f-a2b9-78b0c2a20d05)

