### PR TITLE
Fixed incorrect parse result for filters with outer/wrapped brackets

### DIFF
--- a/packages/mongo-utils/test/mongo-utils.test.js
+++ b/packages/mongo-utils/test/mongo-utils.test.js
@@ -3,7 +3,6 @@
 require('./utils');
 const mongoUtils = require('../');
 const assert = require('assert');
-const nql = require('../../nql');
 
 describe('Find statement', function () {
     it('should match with object statement by key', function () {
@@ -932,22 +931,20 @@ describe('mapKeyValues', function () {
 describe('getUsedKeys', function () {
     it('Returns all keys', function () {
         const query = {
-            yg: {
-                $and: [{
-                    good: {
-                        $ne: false
-                    }
+            $and: [{
+                good: {
+                    $ne: false
+                }
+            }, {
+                $or: [{
+                    something: 'else',
+                    multiple: 'keys'
                 }, {
-                    $or: [{
-                        something: 'else',
-                        multiple: 'keys'
-                    }, {
-                        other: {
-                            $ne: true
-                        }
-                    }]
+                    other: {
+                        $ne: true
+                    }
                 }]
-            }
+            }]
         };
 
         mongoUtils.getUsedKeys(query).should.eql(['good', 'something', 'multiple', 'other']);
@@ -969,34 +966,22 @@ describe('getUsedKeys', function () {
     });
 });
 
-describe('yg filter group', function () {
-    it('The NQL parser can return yg groups', function () {
-        nql('(hello:world)').parse().should.eql({
-            yg: {
-                hello: 'world'
-            }
-        });
-    });
-});
-
 describe('mapKeys', function () {
     it('Maps multiple keys', function () {
         const query = {
-            yg: {
-                $and: [{
-                    good: {
-                        $ne: false
-                    }
+            $and: [{
+                good: {
+                    $ne: false
+                }
+            }, {
+                $or: [{
+                    something: 'else'
                 }, {
-                    $or: [{
-                        something: 'else'
-                    }, {
-                        other: {
-                            $ne: true
-                        }
-                    }]
+                    other: {
+                        $ne: true
+                    }
                 }]
-            }
+            }]
         };
 
         const chained = mongoUtils.chainTransformers(...mongoUtils.mapKeys({
@@ -1006,21 +991,19 @@ describe('mapKeys', function () {
         }));
 
         assert.deepEqual(chained(query), {
-            yg: {
-                $and: [{
-                    bad: {
-                        $ne: false
-                    }
+            $and: [{
+                bad: {
+                    $ne: false
+                }
+            }, {
+                $or: [{
+                    elsewhere: 'else'
                 }, {
-                    $or: [{
-                        elsewhere: 'else'
-                    }, {
-                        another: {
-                            $ne: true
-                        }
-                    }]
+                    another: {
+                        $ne: true
+                    }
                 }]
-            }
+            }]
         });
     });
 });
@@ -1028,21 +1011,19 @@ describe('mapKeys', function () {
 describe('replaceFilters', function () {
     it('Can replace a filter by key', function () {
         const query = {
-            yg: {
-                $and: [{
-                    good: {
-                        $ne: false
-                    }
+            $and: [{
+                good: {
+                    $ne: false
+                }
+            }, {
+                $or: [{
+                    something: 'else'
                 }, {
-                    $or: [{
-                        something: 'else'
-                    }, {
-                        other: {
-                            $ne: true
-                        }
-                    }]
+                    other: {
+                        $ne: true
+                    }
                 }]
-            }
+            }]
         };
 
         const updatedQuery = mongoUtils.replaceFilters(query, {
@@ -1052,21 +1033,19 @@ describe('replaceFilters', function () {
         });
 
         assert.deepEqual(updatedQuery, {
-            yg: {
-                $and: [{
-                    good: {
-                        $ne: false
-                    }
+            $and: [{
+                good: {
+                    $ne: false
+                }
+            }, {
+                $or: [{
+                    else: true
                 }, {
-                    $or: [{
-                        else: true
-                    }, {
-                        other: {
-                            $ne: true
-                        }
-                    }]
+                    other: {
+                        $ne: true
+                    }
                 }]
-            }
+            }]
         });
     });
 });
@@ -1130,21 +1109,19 @@ describe('splitFilter', function () {
 
     it('Does a simple pass through to yg contents', function () {
         const query = {
-            yg: {
-                $and: [{
-                    good: {
-                        $ne: false
-                    }
+            $and: [{
+                good: {
+                    $ne: false
+                }
+            }, {
+                $or: [{
+                    something: 'else'
                 }, {
-                    $or: [{
-                        something: 'else'
-                    }, {
-                        other: {
-                            $ne: true
-                        }
-                    }]
+                    other: {
+                        $ne: true
+                    }
                 }]
-            }
+            }]
         };
 
         const [first, second] = mongoUtils.splitFilter(query, ['good']);

--- a/packages/nql-lang/dist/parser.js
+++ b/packages/nql-lang/dist/parser.js
@@ -84,7 +84,14 @@ performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* actio
 var $0 = $$.length - 1;
 switch (yystate) {
 case 1:
- yy.debug('expression', $$[$0]); yy.debug('opt', opt); return $$[$0]; 
+
+        yy.debug('expression', $$[$0]);
+        yy.debug('opt', opt);
+        if ($$[$0] && $$[$0].yg) {
+            return $$[$0].yg; // Unwrap from 'yg' if present
+        }
+        return $$[$0];
+    
 break;
 case 2:
  yy.debug('andCondition', $$[$0]); this.$ = $$[$0]; 

--- a/packages/nql-lang/src/nql.y
+++ b/packages/nql-lang/src/nql.y
@@ -18,7 +18,14 @@
 %% /* language grammar */
 
 expressions
-    : expression { yy.debug('expression', $1); yy.debug('opt', opt); return $1; }
+    : expression {
+        yy.debug('expression', $1);
+        yy.debug('opt', opt);
+        if ($1 && $1.yg) {
+            return $1.yg; // Unwrap from 'yg' if present
+        }
+        return $1;
+    }
     ;
 
 expression

--- a/packages/nql-lang/test/parser.test.js
+++ b/packages/nql-lang/test/parser.test.js
@@ -189,6 +189,32 @@ describe('Parser', function () {
         });
     });
 
+    describe('Grouping', function () {
+        it('ungroups top level group', function () {
+            parse('(status:published)').should.eql({status: 'published'});
+        });
+
+        it('ungroups top level group with logical query operator', function () {
+            parse('(page:false+status:published)')
+                .should.eql({$and: [{page: false}, {status: 'published'}]});
+        });
+
+        it('ungroups top level group with nested groups', function () {
+            parse('(page:false,(status:published+featured:true))')
+                .should.eql({
+                    $or: [
+                        {page: false},
+                        {
+                            $and: [
+                                {status: 'published'},
+                                {featured: true}
+                            ]
+                        }
+                    ]
+                });
+        });
+    });
+
     describe('complex examples', function () {
         it('Many expressions', function () {
             parse('tag:photo+featured:true,tag.count:>5').should.eql({


### PR DESCRIPTION
fixes https://github.com/TryGhost/NQL/issues/16

With this change, if `yg` is present in the output, it will be removed and its contents will be moved to the parent node