### PR TITLE
Improved performance for multiple negation filters

### DIFF
--- a/packages/nql/lib/nql.js
+++ b/packages/nql/lib/nql.js
@@ -1,16 +1,34 @@
+/**
+ * A module for parsing and applying NQL (Normalized Query Language) queries.
+ * @module nql
+ */
+
 const mingo = require('mingo');
 const nql = require('@tryghost/nql-lang');
 const mongoKnex = require('@tryghost/mongo-knex');
 const utils = require('./utils');
 
+/**
+ * Creates an NQL API object.
+ * @param {string} queryString - The NQL query string.
+ * @param {Object} [options={}] - Additional options for the NQL API.
+ * @returns {Object} The NQL API object.
+ */
 module.exports = (queryString, options = {}) => {
     const api = {};
 
-    // Convert the string to tokens - useful for testing / debugging, maybe for validating?
+    /**
+     * Lexically analyzes the query string and returns an array of tokens.
+     * @returns {Array} An array of tokens.
+     */
     api.lex = () => nql.lex(queryString);
 
-    // Parse converts to mongo JSON and caches the result
+    /**
+     * Parses the query string and converts it to a MongoDB JSON query.
+     * @returns {Object} The MongoDB JSON query.
+     */
     api.parse = function () {
+        // set the filter if not present
         if (!this.filter && queryString) {
             this.filter = nql.parse(queryString);
             if (options.transformer) {
@@ -31,6 +49,9 @@ module.exports = (queryString, options = {}) => {
 
         let mongoJSON = utils.mergeFilters(overrides, this.filter, defaults);
 
+        // this is a performance modification to combine multiple $ne filters into a single $nin filter (see de Morgan's laws)
+        mongoJSON = utils.combineNeFilters(mongoJSON);
+
         if (options.expansions) {
             mongoJSON = utils.expandFilters(mongoJSON, options.expansions);
         }
@@ -38,25 +59,42 @@ module.exports = (queryString, options = {}) => {
         return mongoJSON;
     };
 
-    // Use Mingo to apply the query to a JSON object
-    // @TODO rethink this naming
+    /**
+     * Applies the query to a JSON object using Mingo.
+     * @param {Object} obj - The JSON object to apply the query to.
+     * @returns {boolean} True if the object matches the query, false otherwise.
+     */
     api.queryJSON = function (obj) {
         this.query = this.query || new mingo.Query(api.parse());
         return this.query.test(obj);
     };
 
-    // Use MongoKnex to apply the query to a query builder object
+    /**
+     * Applies the query to a query builder object using MongoKnex.
+     * @param {Object} qb - The query builder object.
+     * @returns {Object} The modified query builder object.
+     */
     api.querySQL = qb => mongoKnex(qb, api.parse(), options);
 
-    // Get back the original query string
+    /**
+     * Returns the original query string.
+     * @returns {string} The original query string.
+     */
     api.toString = () => queryString;
 
-    // Alias parse as toJSON()
+    /**
+     * Alias for the `parse` method.
+     * @returns {Object} The MongoDB JSON query.
+     */
     api.toJSON = api.parse;
 
     return api;
 };
 
+/**
+ * Utility functions for NQL.
+ * @namespace utils
+ */
 module.exports.utils = {
     mapQuery: require('@tryghost/mongo-utils').mapQuery,
     mapKeyValues: require('@tryghost/mongo-utils').mapKeyValues

--- a/packages/nql/lib/utils.js
+++ b/packages/nql/lib/utils.js
@@ -1,6 +1,17 @@
+/**
+ * Utility functions for working with MongoDB queries and expansions.
+ * @module utils
+ */
+
 const mongoUtils = require('@tryghost/mongo-utils');
 const nqlLang = require('@tryghost/nql-lang');
+const _ = require('lodash');
 
+/**
+ * Parses the expansions object and converts the expansion strings into parsed NQL expressions.
+ * @param {Object} expansions - The expansions object.
+ * @returns {Object[]} - The parsed expansions.
+ */
 const parseExpansions = (expansions) => {
     if (!expansions || Object.keys(expansions).length === 0) {
         return expansions;
@@ -17,14 +28,48 @@ const parseExpansions = (expansions) => {
     });
 };
 
+/**
+ * Expands the filters in the given MongoDB query using the provided expansions.
+ * @param {Object} mongoJSON - The MongoDB query object.
+ * @param {Object[]} expansions - The parsed expansions.
+ * @returns {Object} - The expanded MongoDB query object.
+ */
 const expandFilters = (mongoJSON, expansions) => {
     const parsedExpansions = parseExpansions(expansions);
 
     return mongoUtils.expandFilters(mongoJSON, parsedExpansions);
 };
 
+/**
+ * Combines multiple '$ne' filters of the same type within an '$and' operator into a single '$nin' filter.
+ * @param {Object} mongoJSON - The MongoDB query object.
+ * @returns {Object} - The modified MongoDB query object.
+ */
+const combineNeFilters = (mongoJSON) => {
+    // this should only be necessary when we have '$and' with multiple child '$ne' filters of the same type
+    if (mongoUtils.findStatement(mongoJSON, '$ne') && mongoJSON.$and) {
+        const andFilters = mongoJSON.$and;
+        const neFilters = andFilters.filter(filter => mongoUtils.findStatement(filter, '$ne'));
+        const neGroups = _.groupBy(neFilters, filter => Object.keys(filter)[0]);
+        const neKeys = Object.keys(neGroups);
+        const neKeysWithMultipleFilters = neKeys.filter(key => neGroups[key].length > 1);
+        neKeysWithMultipleFilters.forEach((key) => {
+            const neValues = neGroups[key].map(filter => filter[key].$ne);
+            mongoJSON[key] = {$nin: neValues};
+            neGroups[key].forEach((filter) => {
+                andFilters.splice(andFilters.indexOf(filter), 1);
+            });
+        });
+        if (andFilters.length === 0) {
+            delete mongoJSON.$and;
+        }
+    }
+    return mongoJSON;
+};
+
 module.exports = {
     mergeFilters: mongoUtils.mergeFilters,
     parseExpansions: parseExpansions,
-    expandFilters: expandFilters
+    expandFilters: expandFilters,
+    combineNeFilters: combineNeFilters
 };

--- a/packages/nql/test/unit/query.test.js
+++ b/packages/nql/test/unit/query.test.js
@@ -65,4 +65,14 @@ describe('NQL -> SQL', function () {
             query.querySQL(knex('users')).toQuery().should.eql('select * from `users` where lower(`users`.`name`) like \'%\\\';select ** from `settings` where `value` like \\\'%\' ESCAPE \'*\'');
         });
     });
+
+    describe('Will collapse multiple NOT IN filters into a single NOT IN', function () {
+        it('can collapse multiple NOT IN filters into a single NOT IN', function () {
+            let query;
+
+            query = nql('tag:-tag1+tag:-tag2');
+            query.toJSON().should.eql({tag: {$nin: ['tag1', 'tag2']}});
+            query.querySQL(knex('posts')).toQuery().should.eql('select * from `posts` where `posts`.`tag` not in (\'tag1\', \'tag2\')');
+        });
+    });
 });

--- a/packages/nql/test/unit/utils.test.js
+++ b/packages/nql/test/unit/utils.test.js
@@ -102,5 +102,40 @@ describe('Utils', function () {
             utils.parseExpansions(input).should.eql(output);
             input.should.eql(input); // input should not be mutated
         });
+
+        it('should combine $ne filters', function () {
+            const input = {
+                $and: [
+                    {tag: {$ne: 'hash-secondary_feature_1'}},
+                    {tag: {$ne: 'hash-secondary_feature_2'}}
+                ]
+            };
+            const output = {
+                tag: {$nin: ['hash-secondary_feature_1', 'hash-secondary_feature_2']}
+            };
+
+            utils.combineNeFilters(input).should.eql(output);
+        });
+
+        it('should not combine $ne filters when there is only one', function () {
+            const input = {
+                $and: [
+                    {tag: {$ne: 'hash-secondary_feature_1'}}
+                ]
+            };
+
+            utils.combineNeFilters(input).should.eql(input);
+        });
+
+        it('should not combine $ne filters when there are multiple keys with only one filter', function () {
+            const input = {
+                $and: [
+                    {id: {$ne: '8d2ofjoijsd9s09dc'}},
+                    {tag: {$ne: 'hash-secondary_feature_2'}}
+                ]
+            };
+
+            utils.combineNeFilters(input).should.eql(input);
+        });
     });
 });

--- a/packages/nql/test/unit/utils.test.js
+++ b/packages/nql/test/unit/utils.test.js
@@ -137,5 +137,32 @@ describe('Utils', function () {
 
             utils.combineNeFilters(input).should.eql(input);
         });
+
+        it('should not combine $ne filters with $eq filters', function () {
+            const input = {
+                $and: [
+                    {tag: {$ne: '8d2ofjoijsd9s09dc'}},
+                    {tag: 'hash-secondary_feature_2'}
+                ]
+            };
+
+            utils.combineNeFilters(input).should.eql(input);
+        });
+
+        it('does not yet combine groups', function () {
+            const input = {
+                $and: [
+                    {tag: {$ne: 'tag1'}},
+                    {
+                        $and: [
+                            {tag: {$ne: 'tag2'}},
+                            {tag: {$ne: 'tag3'}}
+                        ]
+                    }
+                ]
+            };
+
+            utils.combineNeFilters(input).should.eql(input);
+        });
     });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/CFR-27
- NQL will now automatically combine multiple not equal ($ne) filters of the same type
- added JSDoc

This is a performance improvement as (NOT 1) AND (NOT 2) is logically equal to NOT (1 OR 2), except the latter is *much* more performant in the resulting SQL query as you only get one subquery instaed of one for each filter.