### PR TITLE
Added handling for nested statements when combining ne filters

### DIFF
--- a/packages/nql/test/unit/query.test.js
+++ b/packages/nql/test/unit/query.test.js
@@ -75,6 +75,14 @@ describe('NQL -> SQL', function () {
             query.querySQL(knex('posts')).toQuery().should.eql('select * from `posts` where `posts`.`tag` not in (\'tag1\', \'tag2\')');
         });
 
+        it('can collapse NE filters that are in nested $and statements', function () {
+            let query;
+
+            query = nql('(tag:-tag1+tag:-tag2)+type:post');
+            query.toJSON().should.eql({$and: [{tag: {$nin: ['tag1', 'tag2']}}, {type: 'post'}]});
+            query.querySQL(knex('posts')).toQuery().should.eql('select * from `posts` where (`posts`.`tag` not in (\'tag1\', \'tag2\') and `posts`.`type` = \'post\')');
+        });
+
         it('can collapse multiple NE filters into a single NOT IN', function () {
             let query;
 

--- a/packages/nql/test/unit/utils.test.js
+++ b/packages/nql/test/unit/utils.test.js
@@ -164,5 +164,19 @@ describe('Utils', function () {
 
             utils.combineNeFilters(input).should.eql(input);
         });
+
+        it('should combine $ne filters in nested $and', function () {
+            const input = {
+                $and: [
+                    {tag: {$ne: 'tag1'}},
+                    {tag: {$ne: 'tag2'}}
+                ]
+            };
+            const output = {
+                tag: {$nin: ['tag1', 'tag2']}
+            };
+
+            utils.combineNeFilters(input).should.eql(output);
+        });
     });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/CFR-27
- the combineNeFilters performance improvement will now work with nested operators

Some Ghost serializers wrap the filter strings, so we need to be able to handle nested statements in order for the performance improvement to be useful, specifically with {{#get}} helpers fetching posts.