### PR TITLE
Dropped Node v16 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ jobs:
       database__connection__database: nql_testing
     name: Node ${{ matrix.node }}, ${{ matrix.env.DB }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         env:
           FORCE_COLOR: 0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 18 ]
+        node: [ 18, 20 ]
         env:
           - DB: sqlite3
             NODE_ENV: testing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 16, 18 ]
+        node: [ 18 ]
         env:
           - DB: sqlite3
             NODE_ENV: testing


### PR DESCRIPTION
- Node 16 support was dropped in Sep 2023, we shouldn't run tests against it anymore