### PR TITLE
Added dependency compatibility tests

### DIFF
--- a/packages/nql-lang/test/scope.test.js
+++ b/packages/nql-lang/test/scope.test.js
@@ -1,0 +1,21 @@
+require('./utils');
+
+const scope = require('../lib/scope');
+
+describe('Scope date helpers', function () {
+    it('formats dates for SQL in UTC', function () {
+        const result = scope.relDateToAbsolute('sub', 1, 'd');
+
+        result.should.match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    });
+
+    it('supports all interval units', function () {
+        const intervals = ['d', 'w', 'M', 'y', 'h', 'm', 's'];
+
+        intervals.forEach(function (interval) {
+            const result = scope.relDateToAbsolute('add', 2, interval);
+
+            result.should.match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+        });
+    });
+});

--- a/packages/nql/test/integration/mingo_compatibility.test.js
+++ b/packages/nql/test/integration/mingo_compatibility.test.js
@@ -1,0 +1,23 @@
+require('../utils');
+
+const mingo = require('mingo');
+
+describe('Mingo compatibility', function () {
+    it('exposes the Query class', function () {
+        mingo.Query.should.be.a.Function();
+    });
+
+    it('can evaluate basic queries', function () {
+        const query = new mingo.Query({id: 1});
+
+        query.test({id: 1}).should.eql(true);
+        query.test({id: 2}).should.eql(false);
+    });
+
+    it('can handle logical operators', function () {
+        const query = new mingo.Query({$and: [{status: 'draft'}, {featured: false}]});
+
+        query.test({status: 'draft', featured: false}).should.eql(true);
+        query.test({status: 'published', featured: false}).should.eql(false);
+    });
+});


### PR DESCRIPTION
closes #102

- add Mingo compatibility coverage to lock in Query behavior
- add scope date helper tests to validate formatted SQL timestamps

Test plan:
- yarn test