### PR TITLE
Updated test workflow triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'renovate/*'
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
closes #104 

- remove Renovate branches from push-triggered CI
- rely on pull_request runs to keep coverage without duplication

Test plan:
- CI