### PR TITLE
Updated CI Node versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 18, 20 ]
+        node: [ 22, 24 ]
         env:
           - DB: sqlite3
             NODE_ENV: testing


### PR DESCRIPTION
closes #106

- move test matrix to Node 22 and 24 to match current support
- drop legacy Node 18/20 coverage from CI

Test plan:
- CI