### PR TITLE
Added required tests check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,3 +53,13 @@ jobs:
           status: ${{ job.status }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  required-tests:
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ always() }}
+    name: Required tests
+    steps:
+      - name: Check matrix status
+        if: ${{ needs.test.result != 'success' }}
+        run: exit 1


### PR DESCRIPTION
closes #108

- add a stable Required tests job for the CI matrix
- fail that job when any matrix entry fails, so branch protection can target one check

Test plan:
- CI