### PR TITLE
Use renovate-config directly for Renovate presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "@tryghost:quietJS"
+    "github>TryGhost/renovate-config"
   ]
 }


### PR DESCRIPTION
## Summary
- replace the legacy `@tryghost:quietJS` preset reference
- use `github>TryGhost/renovate-config` directly as the shared preset source
- align NQL with the current org standard for Renovate configuration