### PR TITLE
Declared lodash as a runtime dependency of @tryghost/nql

### DIFF
--- a/packages/nql/package.json
+++ b/packages/nql/package.json
@@ -31,6 +31,7 @@
     "@tryghost/mongo-knex": "^0.9.4",
     "@tryghost/mongo-utils": "^0.6.3",
     "@tryghost/nql-lang": "^0.6.4",
+    "lodash": "^4.17.21",
     "mingo": "^2.2.2"
   }
 }


### PR DESCRIPTION
## Summary
- `lib/utils.js` does `require('lodash')` (single use: `_.groupBy`) but lodash was not in `dependencies`.
- This was a latent phantom dependency that worked accidentally via hoisting in npm/yarn classic and in pnpm with `shamefully-hoist=true`. Strict pnpm isolation breaks it.
- Sibling packages `@tryghost/mongo-knex` and `@tryghost/mongo-utils` already declare `lodash` with the same `^4.17.21` range — so this just brings `nql` into line.

## Context
Surfaced in [TryGhost/Ghost](https://github.com/TryGhost/Ghost) after `shamefully-hoist` was disabled in [#27343](https://github.com/TryGhost/Ghost/pull/27343). Vite's esbuild optimizer fails with:

```
✘ [ERROR] Could not resolve "lodash"
  ../../node_modules/.pnpm/@tryghost+nql@0.12.10/node_modules/@tryghost/nql/lib/utils.js:8:18:
    8 │ const _ = require('lodash');
```

The Ghost side is also being patched with a workspace-level phantom declaration so admin development isn't blocked while waiting for an `@tryghost/nql` release.

## Test plan
- [x] `yarn test` in `packages/nql` — 75 passing, 100% coverage
- [x] `yarn lint` clean
- [x] No `yarn.lock` change (lodash was already resolved transitively; this just records the intent)