### PR TITLE
Add preserveRelativeDates parse option

### DIFF
--- a/packages/nql-lang/lib/nql.js
+++ b/packages/nql-lang/lib/nql.js
@@ -1,5 +1,6 @@
+const scope = require('./scope');
 const parser = require('../dist/parser').parser;
-parser.yy = require('./scope');
+parser.yy = scope;
 
 exports.lex = (input) => {
     parser.lexer.setInput(input);
@@ -15,4 +16,20 @@ exports.lex = (input) => {
 };
 
 // returns the JSON object
-exports.parse = (input, options) => parser.parse(input, options || {});
+//
+// `options.preserveRelativeDates` (default false): when true, relative-date
+// expressions like `now-7d` are emitted as `{$relativeDate: {op, amount, unit}}`
+// instead of being resolved to an absolute SQL-formatted date at parse time.
+// This lets consumers (e.g. UI clients that need to render the relative form)
+// distinguish "in the last 7 days" from a literal date comparison. Default
+// behaviour is unchanged for callers that don't opt in.
+exports.parse = (input, options) => {
+    const opts = options || {};
+    scope.preserveRelativeDates = opts.preserveRelativeDates === true;
+
+    try {
+        return parser.parse(input, opts);
+    } finally {
+        scope.preserveRelativeDates = false;
+    }
+};

--- a/packages/nql-lang/lib/scope.js
+++ b/packages/nql-lang/lib/scope.js
@@ -57,6 +57,14 @@ module.exports = {
     },
 
     relDateToAbsolute(op, amount, duration) {
+        // When the parse caller has opted in via `preserveRelativeDates: true`,
+        // emit a tagged value so consumers can distinguish a relative-date
+        // expression from an absolute one. The default path resolves the
+        // relative form to an absolute SQL-formatted date as before.
+        if (this.preserveRelativeDates) {
+            return {$relativeDate: {op, amount: Number(amount), unit: intervals[duration]}};
+        }
+
         const now = new Date();
         const relDate = ops[op](now, {[intervals[duration]]: amount});
 

--- a/packages/nql-lang/test/parser.test.js
+++ b/packages/nql-lang/test/parser.test.js
@@ -628,6 +628,69 @@ describe('Parser', function () {
             });
         });
 
+        describe('preserveRelativeDates option', function () {
+            it('emits a tagged $relativeDate value instead of an absolute date when enabled', function () {
+                parse('last_seen_at:>=now-7d', {preserveRelativeDates: true}).should.eql({
+                    last_seen_at: {$gte: {$relativeDate: {op: 'sub', amount: 7, unit: 'days'}}}
+                });
+
+                parse('last_seen_at:<=now+14d', {preserveRelativeDates: true}).should.eql({
+                    last_seen_at: {$lte: {$relativeDate: {op: 'add', amount: 14, unit: 'days'}}}
+                });
+            });
+
+            it('preserves relative dates inside grouped/compound expressions', function () {
+                parse('(label:vip+created_at:>=now-30d)', {preserveRelativeDates: true}).should.eql({
+                    $and: [
+                        {label: 'vip'},
+                        {created_at: {$gte: {$relativeDate: {op: 'sub', amount: 30, unit: 'days'}}}}
+                    ]
+                });
+
+                parse('created_at:>=now-7d,status:paid', {preserveRelativeDates: true}).should.eql({
+                    $or: [
+                        {created_at: {$gte: {$relativeDate: {op: 'sub', amount: 7, unit: 'days'}}}},
+                        {status: 'paid'}
+                    ]
+                });
+            });
+
+            it('leaves absolute dates untouched when enabled', function () {
+                parse('created_at:>=\'2024-01-01\'', {preserveRelativeDates: true}).should.eql({
+                    created_at: {$gte: '2024-01-01'}
+                });
+            });
+
+            it('preserves the same units the lexer recognises', function () {
+                const intervals = [
+                    ['d', 'days'],
+                    ['w', 'weeks'],
+                    ['M', 'months'],
+                    ['y', 'years'],
+                    ['h', 'hours'],
+                    ['m', 'minutes'],
+                    ['s', 'seconds']
+                ];
+
+                intervals.forEach(function ([short, long]) {
+                    parse(`last_seen_at:>=now-2${short}`, {preserveRelativeDates: true}).should.eql({
+                        last_seen_at: {$gte: {$relativeDate: {op: 'sub', amount: 2, unit: long}}}
+                    });
+                });
+            });
+
+            it('does not affect later parses that omit the option', function () {
+                parse('last_seen_at:>=now-7d', {preserveRelativeDates: true}).should.eql({
+                    last_seen_at: {$gte: {$relativeDate: {op: 'sub', amount: 7, unit: 'days'}}}
+                });
+
+                const followUp = parse('last_seen_at:>=now-7d');
+                followUp.should.be.an.Object().with.property('last_seen_at');
+                followUp.last_seen_at.should.have.property('$gte');
+                followUp.last_seen_at.$gte.should.match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+            });
+        });
+
         describe('Single character literals', function () {
             it('can handle single character literals', function () {
                 parse('name:a').should.eql({name: 'a'});

--- a/packages/nql-lang/test/scope.test.js
+++ b/packages/nql-lang/test/scope.test.js
@@ -18,4 +18,38 @@ describe('Scope date helpers', function () {
             result.should.match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
         });
     });
+
+    describe('with preserveRelativeDates flag set', function () {
+        afterEach(function () {
+            scope.preserveRelativeDates = false;
+        });
+
+        it('returns a tagged value instead of an absolute date', function () {
+            scope.preserveRelativeDates = true;
+
+            scope.relDateToAbsolute('sub', '7', 'd').should.eql({
+                $relativeDate: {op: 'sub', amount: 7, unit: 'days'}
+            });
+        });
+
+        it('coerces the amount to a number and spells out the unit for every interval', function () {
+            scope.preserveRelativeDates = true;
+
+            const cases = [
+                ['d', 'days'],
+                ['w', 'weeks'],
+                ['M', 'months'],
+                ['y', 'years'],
+                ['h', 'hours'],
+                ['m', 'minutes'],
+                ['s', 'seconds']
+            ];
+
+            cases.forEach(function ([short, long]) {
+                scope.relDateToAbsolute('add', '3', short).should.eql({
+                    $relativeDate: {op: 'add', amount: 3, unit: long}
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Adds an opt-in `preserveRelativeDates` option to `nql-lang.parse()`. When enabled, relative-date expressions like `now-7d` are emitted as a tagged value rather than being resolved to an absolute SQL-formatted date at parse time:

```js
parse('created_at:>=now-7d', {preserveRelativeDates: true});
// → {created_at: {$gte: {$relativeDate: {op: 'sub', amount: 7, unit: 'days'}}}}
```

Default behaviour is unchanged for callers that don't pass the option.

## Why

UI clients that round-trip NQL strings through the parser currently lose the relative form (e.g. "in the last 7 days" becomes a fixed date the moment `parse()` runs). Consumers wanting to render the relative form have to detect it via string-level regex *before* calling the parser — duplicating the grammar's tokenisation work, and inevitably falling short for nested or compound expressions.

The grammar already recognises relative-date syntax as a distinct production rule (`NOW DATEOP AMOUNT INTERVAL` in `nql.y`); this PR just lets that recognition reach the AST when the caller asks for it. Server-side / SQL callers continue to get absolute dates.