### PR TITLE
Pin GitHub Actions workflow actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -37,8 +41,8 @@ jobs:
       database__connection__database: nql_testing
     name: Node ${{ matrix.node }}, ${{ matrix.env.DB }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         env:
           FORCE_COLOR: 0
         with:
@@ -54,9 +58,9 @@ jobs:
       - run: yarn
       - run: yarn test
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
 
-      - uses: tryghost/actions/actions/slack-build@main
+      - uses: tryghost/actions/actions/slack-build@128d496a57fb11e44e97d690f0d5381c58e52489 # main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
## Summary

- Pin all actions used by the `Test` workflow to full-length commit SHAs
- Add explicit read-only `contents` permissions for the workflow token

## Why

The NQL `Test` workflow is currently failing during job setup after GitHub Actions security was tightened. The runner rejects unpinned action refs such as `actions/checkout@v6`, `actions/setup-node@v6`, `codecov/codecov-action@v5`, and `tryghost/actions/actions/slack-build@main`.

## Validation

- `git diff --check`
- Parsed `.github/workflows/test.yml` as YAML
- Checked that the workflow no longer contains `uses:` refs pinned to version tags or branch names