### PR TITLE
✨ Added aggregate relation type to mongo-knex

### DIFF
--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -641,8 +641,13 @@ class MongoToKnex {
                 const useOr = idx !== 0 && ((mode === '$or') !== invertSubquery);
                 const havingType = useOr ? 'orHavingRaw' : 'havingRaw';
 
+                // CASE: values are validated numeric but can arrive as numeric strings
+                //       (e.g. quoted filter values) - they are bound as numbers so the
+                //       database comparison matches the inversion decision above, which
+                //       evaluates the predicate via Number() (e.g. SQLite would never
+                //       coerce, an integer aggregate always sorts below any string)
                 if (isStatementGroupOp(compOps[operator])) {
-                    const statementValue = _.castArray(statement.value);
+                    const statementValue = _.castArray(statement.value).map(Number);
 
                     // CASE: IN () is invalid SQL and an empty set can never match
                     if (statementValue.length === 0) {
@@ -653,7 +658,7 @@ class MongoToKnex {
                     const placeholders = statementValue.map(() => '?').join(', ');
                     innerQB[havingType](`${aggregateFunction} ${compOps[operator]} (${placeholders})`, [config.aggregate.column, ...statementValue]);
                 } else {
-                    innerQB[havingType](`${aggregateFunction} ${compOps[operator]} ?`, [config.aggregate.column, statement.value]);
+                    innerQB[havingType](`${aggregateFunction} ${compOps[operator]} ?`, [config.aggregate.column, Number(statement.value)]);
                 }
             });
 

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -147,10 +147,13 @@ class MongoToKnex {
      *      type: 'aggregate'
      *      aggregate: {fn: String (e.g. countDistinct), column: String (e.g. posts_tags.tag_id)}
      *      tableName: String (e.g. posts_tags) - table holding the related rows
+     *      tableNameAs: String (optional) - alias for tableName, e.g. for self-joins
      *      joinFrom: String (e.g. post_id) - column on tableName referencing the parent table's id
-     *      joins: [{tableName, from, to}] (optional) - chain of joins needed to qualify rows
+     *      joins: [{tableName, tableNameAs (optional), from, to}] (optional) - chain of joins needed to qualify rows
      *      wheres: {[column]: value} (optional) - fixed conditions a related row must meet to be counted
      *  }
+     *
+     * When tableNameAs is used, aggregate.column and wheres must reference the alias.
      */
     constructor(options = {}, config = {}) {
         this.tableName = options.tableName;
@@ -558,25 +561,34 @@ class MongoToKnex {
         const comp = invertSubquery ? compOps.$nin : compOps.$in;
         const whereType = reference.whereType === 'orWhere' ? 'orWhere' : 'where';
 
+        // CASE: you can define a name for the aggregated table and any joined table,
+        //       e.g. for self-joins or when a table appears elsewhere in the query -
+        //       aggregate.column and wheres must then reference the aliases
+        const baseTable = config.tableNameAs || config.tableName;
+        const baseTableValue = config.tableNameAs ? `${config.tableName} as ${config.tableNameAs}` : config.tableName;
+
         // CASE: WHERE resource.id (IN | NOT IN) (SELECT ... GROUP BY ... HAVING ...)
         qb[whereType](`${this.tableName}.id`, comp, function () {
             const innerQB = this
-                .select(`${config.tableName}.${config.joinFrom}`)
-                .from(config.tableName);
+                .select(`${baseTable}.${config.joinFrom}`)
+                .from(baseTableValue);
 
             // CASE: a single NULL in a NOT IN list makes the comparison UNKNOWN for every
             //       parent row, so an orphaned related row (NULL joinFrom) would silently
             //       empty the whole result set
             if (invertSubquery) {
-                innerQB.whereNotNull(`${config.tableName}.${config.joinFrom}`);
+                innerQB.whereNotNull(`${baseTable}.${config.joinFrom}`);
             }
 
             // CASE: qualifying related rows can live across a chain of joined tables,
             //       each join's `from` column references the `to` column of the previous table
-            let previousTable = config.tableName;
+            let previousTable = baseTable;
             _.each(config.joins, (join) => {
-                innerQB.innerJoin(join.tableName, `${join.tableName}.${join.from}`, `${previousTable}.${join.to}`);
-                previousTable = join.tableName;
+                const joinTable = join.tableNameAs || join.tableName;
+                const joinTableValue = join.tableNameAs ? `${join.tableName} as ${join.tableNameAs}` : join.tableName;
+
+                innerQB.innerJoin(joinTableValue, `${joinTable}.${join.from}`, `${previousTable}.${join.to}`);
+                previousTable = joinTable;
             });
 
             // CASE: fixed conditions a related row must meet to be counted live in
@@ -591,7 +603,7 @@ class MongoToKnex {
                 innerQB.where(`${joinFilter.joinTable}.${joinFilter.column}`, compOps[joinFilter.operator], joinFilter.value);
             });
 
-            innerQB.groupBy(`${config.tableName}.${config.joinFrom}`);
+            innerQB.groupBy(`${baseTable}.${config.joinFrom}`);
 
             _.each(statements, (statement, idx) => {
                 debug(`(buildAggregateRelationQuery) build aggregate having statement for ${idx}`);

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -20,6 +20,32 @@ const compOps = {
     $not: 'not like'
 };
 
+// Aggregate relations compare a computed numeric value (e.g. a related-row count)
+// rather than a column, so only the comparison operators below make sense
+const aggregateCompOps = ['$eq', '$ne', '$gt', '$gte', '$lt', '$lte', '$in', '$nin'];
+
+// Operator complements, used to invert an aggregate predicate: NOT (x $op y) === x $complement y
+const complementOps = {
+    $eq: '$ne',
+    $ne: '$eq',
+    $gt: '$lte',
+    $gte: '$lt',
+    $lt: '$gte',
+    $lte: '$gt',
+    $in: '$nin',
+    $nin: '$in'
+};
+
+// SQL templates for the supported aggregate functions, ?? is bound to the configured column
+const aggregateFunctions = {
+    count: 'count(??)',
+    countDistinct: 'count(distinct ??)',
+    sum: 'sum(??)',
+    avg: 'avg(??)',
+    min: 'min(??)',
+    max: 'max(??)'
+};
+
 // We don't use a backslash as escpae character, because knex reescapes backslashes in binded parameters
 const likeEscapeCharacter = '*';
 
@@ -29,6 +55,26 @@ const isCompOp = key => isOp(key) && _.includes(_.keys(compOps), key);
 const isNegationOp = key => isOp(key) && _.includes(['$ne', '$nin'], key);
 const isRangeOp = key => isOp(key) && _.includes(['$gt', '$gte', '$lt', '$lte'], key);
 const isStatementGroupOp = key => _.includes([compOps.$in, compOps.$nin], key);
+const isAggregateCompOp = key => _.includes(aggregateCompOps, key);
+
+/**
+ * Whether an aggregate comparison would match a parent row with no related rows
+ * (aggregate value 0). Such rows don't appear in the grouped subquery at all, so
+ * the subquery has to be inverted (NOT IN + complement operator) to include them.
+ */
+const aggregateMatchesZero = (op, value) => {
+    switch (op) {
+    case '$eq': return Number(value) === 0;
+    case '$ne': return Number(value) !== 0;
+    case '$gt': return Number(value) < 0;
+    case '$gte': return Number(value) <= 0;
+    case '$lt': return Number(value) > 0;
+    case '$lte': return Number(value) >= 0;
+    case '$in': return _.castArray(value).some(v => Number(v) === 0);
+    case '$nin': return !_.castArray(value).some(v => Number(v) === 0);
+    default: return false;
+    }
+};
 
 /**
  * JSON Stringify with RegExp support
@@ -88,6 +134,18 @@ class MongoToKnex {
      *      joinTable: String (e.g.  posts_tags)
      *      joinFrom: String (e.g. post_id)
      *      joinTo: String (e.g. tag_id)
+     *  }
+     *
+     * `aggregate` relations compare a computed value over related rows instead of
+     * a column, e.g. `tag_count.count:>1`. The dotted suffix (`count`) is purely
+     * descriptive - what is computed is defined by the relation config:
+     *  {[relation-name]}: {
+     *      type: 'aggregate'
+     *      aggregate: {fn: String (e.g. countDistinct), column: String (e.g. posts_tags.tag_id)}
+     *      tableName: String (e.g. posts_tags) - table holding the related rows
+     *      joinFrom: String (e.g. post_id) - column on tableName referencing the parent table's id
+     *      joins: [{tableName, from, to}] (optional) - chain of joins needed to qualify rows
+     *      wheres: {[column]: value} (optional) - fixed conditions a related row must meet to be counted
      *  }
      */
     constructor(options = {}, config = {}) {
@@ -436,7 +494,91 @@ class MongoToKnex {
                 } else {
                     debug(`one of ${key} group statements contains unknown operator`);
                 }
+            } else if (reference.config.type === 'aggregate') {
+                if (_.every(statements, s => isAggregateCompOp(s.operator) && s.value !== null)) {
+                    this.buildAggregateRelationQuery(qb, statements, reference, mode);
+                } else {
+                    debug(`one of ${key} group statements contains an operator not supported for aggregate relations`);
+                }
             }
+        });
+    }
+
+    /**
+     * Build a grouped subquery for an `aggregate` relation, e.g. for `tag_count.count > 1`:
+     *
+     *      WHERE posts.id IN (
+     *          SELECT posts_tags.post_id FROM posts_tags
+     *          GROUP BY posts_tags.post_id
+     *          HAVING COUNT(posts_tags.tag_id) > 1
+     *      )
+     *
+     * A parent row with no related rows does not appear in the grouped subquery at all,
+     * so when the group's predicate matches an aggregate value of 0 (e.g. `count < 2`)
+     * the query is inverted: NOT IN with the complement predicate (`count >= 2`). Inverting
+     * the predicate also flips the conjunction between statements (De Morgan).
+     */
+    buildAggregateRelationQuery(qb, statements, reference, mode) {
+        const config = reference.config;
+        const aggregateFunction = aggregateFunctions[config.aggregate.fn];
+
+        if (!aggregateFunction) {
+            //eslint-disable-next-line ghost/ghost-custom/no-native-error
+            throw new Error(`Unknown aggregate function: ${config.aggregate.fn}`);
+        }
+
+        // CASE: statements within a group are combined with AND ($and) or OR ($or),
+        //       so the group matches a zero aggregate when every/some statement does
+        const negateGroup = (mode === '$or')
+            ? _.some(statements, s => aggregateMatchesZero(s.operator, s.value))
+            : _.every(statements, s => aggregateMatchesZero(s.operator, s.value));
+
+        const comp = negateGroup ? compOps.$nin : compOps.$in;
+        const whereType = reference.whereType === 'orWhere' ? 'orWhere' : 'where';
+
+        // CASE: WHERE resource.id (IN | NOT IN) (SELECT ... GROUP BY ... HAVING ...)
+        qb[whereType](`${this.tableName}.id`, comp, function () {
+            const innerQB = this
+                .select(`${config.tableName}.${config.joinFrom}`)
+                .from(config.tableName);
+
+            // CASE: qualifying related rows can live across a chain of joined tables,
+            //       each join's `from` column references the `to` column of the previous table
+            let previousTable = config.tableName;
+            _.each(config.joins, (join) => {
+                innerQB.innerJoin(join.tableName, `${join.tableName}.${join.from}`, `${previousTable}.${join.to}`);
+                previousTable = join.tableName;
+            });
+
+            // CASE: fixed conditions a related row must meet to be counted live in
+            //       the relation config, they are not part of the filter input
+            _.each(config.wheres, (value, column) => {
+                innerQB.where(column, value);
+            });
+
+            innerQB.groupBy(`${config.tableName}.${config.joinFrom}`);
+
+            _.each(statements, (statement, idx) => {
+                debug(`(buildAggregateRelationQuery) build aggregate having statement for ${idx}`);
+
+                const operator = negateGroup ? complementOps[statement.operator] : statement.operator;
+                const useOr = idx !== 0 && ((mode === '$or') !== negateGroup);
+                const havingType = useOr ? 'orHavingRaw' : 'havingRaw';
+
+                if (isStatementGroupOp(compOps[operator])) {
+                    const statementValue = _.castArray(statement.value);
+                    const placeholders = statementValue.map(() => '?').join(', ');
+                    innerQB[havingType](`${aggregateFunction} ${compOps[operator]} (${placeholders})`, [config.aggregate.column, ...statementValue]);
+                } else {
+                    innerQB[havingType](`${aggregateFunction} ${compOps[operator]} ?`, [config.aggregate.column, statement.value]);
+                }
+            });
+
+            if (debugExtended.enabled) {
+                debug(`(buildAggregateRelationQuery) innerQB sql: ${innerQB.toSQL().sql}`);
+            }
+
+            return innerQB;
         });
     }
 

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -20,11 +20,9 @@ const compOps = {
     $not: 'not like'
 };
 
-// Aggregate relations compare a computed numeric value (e.g. a related-row count)
-// rather than a column, so only the comparison operators below make sense
-const aggregateCompOps = ['$eq', '$ne', '$gt', '$gte', '$lt', '$lte', '$in', '$nin'];
-
-// Operator complements, used to invert an aggregate predicate: NOT (x $op y) === x $complement y
+// Operator complements, used to invert an aggregate predicate: NOT (x $op y) === x $complement y.
+// The key set doubles as the list of operators supported for aggregate relations - they compare
+// a computed numeric value (e.g. a related-row count) rather than a column, so only these make sense
 const complementOps = {
     $eq: '$ne',
     $ne: '$eq',
@@ -54,7 +52,14 @@ const isCompOp = key => isOp(key) && _.includes(_.keys(compOps), key);
 const isNegationOp = key => isOp(key) && _.includes(['$ne', '$nin'], key);
 const isRangeOp = key => isOp(key) && _.includes(['$gt', '$gte', '$lt', '$lte'], key);
 const isStatementGroupOp = key => _.includes([compOps.$in, compOps.$nin], key);
-const isAggregateCompOp = key => _.includes(aggregateCompOps, key);
+const isAggregateCompOp = key => Boolean(complementOps[key]);
+
+// Aggregate values must be numeric: the inversion decision below evaluates the predicate
+// at 0 in JS, so a value the database would coerce differently (null, '', '2abc') must be
+// rejected up front or the two evaluations can disagree
+const isNumericScalar = value => (_.isNumber(value) && Number.isFinite(value))
+    || (_.isString(value) && value.trim() !== '' && Number.isFinite(Number(value)));
+const isAggregateValue = value => (_.isArray(value) ? _.every(value, isNumericScalar) : isNumericScalar(value));
 
 /**
  * Whether an aggregate comparison would match a parent row with no related rows
@@ -494,10 +499,10 @@ class MongoToKnex {
                     debug(`one of ${key} group statements contains unknown operator`);
                 }
             } else if (reference.config.type === 'aggregate') {
-                if (_.every(statements, s => isAggregateCompOp(s.operator) && s.value !== null)) {
-                    this.buildAggregateRelationQuery(qb, statements, reference, mode);
+                if (_.every(statements, s => isAggregateCompOp(s.operator) && isAggregateValue(s.value))) {
+                    this.buildAggregateRelationQuery(qb, statements, reference, mode, groupedRelations[key].joinFilterStatements);
                 } else {
-                    debug(`one of ${key} group statements contains an operator not supported for aggregate relations`);
+                    debug(`one of ${key} group statements contains an operator or value not supported for aggregate relations`);
                 }
             }
         });
@@ -517,8 +522,14 @@ class MongoToKnex {
      * the query is inverted: NOT IN with the complement predicate (`count >= 2`). Inverting
      * the predicate also flips the conjunction between statements (De Morgan).
      */
-    buildAggregateRelationQuery(qb, statements, reference, mode) {
+    buildAggregateRelationQuery(qb, statements, reference, mode, joinFilterStatements) {
         const config = reference.config;
+
+        if (!config.aggregate || !config.aggregate.fn || !config.aggregate.column) {
+            //eslint-disable-next-line ghost/ghost-custom/no-native-error
+            throw new Error('Aggregate relations require an aggregate config with fn and column');
+        }
+
         const aggregateFunction = aggregateFunctions[config.aggregate.fn];
 
         if (!aggregateFunction) {
@@ -528,11 +539,11 @@ class MongoToKnex {
 
         // CASE: statements within a group are combined with AND ($and) or OR ($or),
         //       so the group matches a zero aggregate when every/some statement does
-        const negateGroup = (mode === '$or')
+        const invertSubquery = (mode === '$or')
             ? _.some(statements, s => aggregateMatchesZero(s.operator, s.value))
             : _.every(statements, s => aggregateMatchesZero(s.operator, s.value));
 
-        const comp = negateGroup ? compOps.$nin : compOps.$in;
+        const comp = invertSubquery ? compOps.$nin : compOps.$in;
         const whereType = reference.whereType === 'orWhere' ? 'orWhere' : 'where';
 
         // CASE: WHERE resource.id (IN | NOT IN) (SELECT ... GROUP BY ... HAVING ...)
@@ -540,6 +551,13 @@ class MongoToKnex {
             const innerQB = this
                 .select(`${config.tableName}.${config.joinFrom}`)
                 .from(config.tableName);
+
+            // CASE: a single NULL in a NOT IN list makes the comparison UNKNOWN for every
+            //       parent row, so an orphaned related row (NULL joinFrom) would silently
+            //       empty the whole result set
+            if (invertSubquery) {
+                innerQB.whereNotNull(`${config.tableName}.${config.joinFrom}`);
+            }
 
             // CASE: qualifying related rows can live across a chain of joined tables,
             //       each join's `from` column references the `to` column of the previous table
@@ -555,17 +573,32 @@ class MongoToKnex {
                 innerQB.where(column, value);
             });
 
+            // CASE: when applying AND conjunction, filters on a join table restrict
+            //       which related rows are aggregated (same as the other relation types)
+            _.each(joinFilterStatements, (joinFilter) => {
+                innerQB.where(`${joinFilter.joinTable}.${joinFilter.column}`, compOps[joinFilter.operator], joinFilter.value);
+            });
+
             innerQB.groupBy(`${config.tableName}.${config.joinFrom}`);
 
             _.each(statements, (statement, idx) => {
                 debug(`(buildAggregateRelationQuery) build aggregate having statement for ${idx}`);
 
-                const operator = negateGroup ? complementOps[statement.operator] : statement.operator;
-                const useOr = idx !== 0 && ((mode === '$or') !== negateGroup);
+                const operator = invertSubquery ? complementOps[statement.operator] : statement.operator;
+                // CASE: inverting the predicate also flips the conjunction between
+                //       statements (De Morgan), hence the XOR with the mode
+                const useOr = idx !== 0 && ((mode === '$or') !== invertSubquery);
                 const havingType = useOr ? 'orHavingRaw' : 'havingRaw';
 
                 if (isStatementGroupOp(compOps[operator])) {
                     const statementValue = _.castArray(statement.value);
+
+                    // CASE: IN () is invalid SQL and an empty set can never match
+                    if (statementValue.length === 0) {
+                        innerQB[havingType]('1 = 0');
+                        return;
+                    }
+
                     const placeholders = statementValue.map(() => '?').join(', ');
                     innerQB[havingType](`${aggregateFunction} ${compOps[operator]} (${placeholders})`, [config.aggregate.column, ...statementValue]);
                 } else {

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -141,8 +141,8 @@ class MongoToKnex {
      *  }
      *
      * `aggregate` relations compare a computed value over related rows instead of
-     * a column, e.g. `tag_count.count:>1`. The dotted suffix (`count`) is purely
-     * descriptive - what is computed is defined by the relation config:
+     * a column, so they are queried by bare relation name, e.g. `tag_count:>1` -
+     * what is computed is defined by the relation config:
      *  {[relation-name]}: {
      *      type: 'aggregate'
      *      aggregate: {fn: String (e.g. countDistinct), column: String (e.g. posts_tags.tag_id)}
@@ -188,6 +188,14 @@ class MongoToKnex {
             const table = tableName;
             let relation = this.config.relations[table];
 
+            // CASE: aggregate relations compare a single computed value, there is no
+            //       column to select - a dotted suffix is meaningless and only invites
+            //       aliased spellings of the same query, so it's rejected outright
+            if (relation && relation.type === 'aggregate') {
+                //eslint-disable-next-line ghost/ghost-custom/no-native-error
+                throw new Error(`Aggregate relation "${table}" is queried by name only, without a column (e.g. "${table}:0")`);
+            }
+
             if (!relation) {
                 // CASE: you want to filter by a column on the join table
                 relation = _.find(this.config.relations, (_relation) => {
@@ -221,6 +229,21 @@ class MongoToKnex {
                 operator: op,
                 value: value,
                 config: relation,
+                isRelation: true
+            };
+        }
+
+        // CASE: aggregate relations are queried by bare name (e.g. `tag_count:>1`),
+        //       the relation config takes precedence over a parent table column of
+        //       the same name
+        const aggregateRelation = this.config.relations[column];
+        if (aggregateRelation && aggregateRelation.type === 'aggregate') {
+            return {
+                table: column,
+                column: null,
+                operator: op,
+                value: value,
+                config: aggregateRelation,
                 isRelation: true
             };
         }
@@ -524,7 +547,7 @@ class MongoToKnex {
     }
 
     /**
-     * Build a grouped subquery for an `aggregate` relation, e.g. for `tag_count.count > 1`:
+     * Build a grouped subquery for an `aggregate` relation, e.g. for `tag_count > 1`:
      *
      *      WHERE posts.id IN (
      *          SELECT posts_tags.post_id FROM posts_tags

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -499,11 +499,17 @@ class MongoToKnex {
                     debug(`one of ${key} group statements contains unknown operator`);
                 }
             } else if (reference.config.type === 'aggregate') {
-                if (_.every(statements, s => isAggregateCompOp(s.operator) && isAggregateValue(s.value))) {
-                    this.buildAggregateRelationQuery(qb, statements, reference, mode, groupedRelations[key].joinFilterStatements);
-                } else {
-                    debug(`one of ${key} group statements contains an operator or value not supported for aggregate relations`);
+                // CASE: unlike the other relation types we throw instead of silently dropping
+                //       the group - a dropped statement widens the result set, returning rows
+                //       the filter was meant to exclude
+                const invalidStatement = statements.find(s => !isAggregateCompOp(s.operator) || !isAggregateValue(s.value));
+
+                if (invalidStatement) {
+                    //eslint-disable-next-line ghost/ghost-custom/no-native-error
+                    throw new Error(`Aggregate relation "${invalidStatement.table}" only supports ${Object.keys(complementOps).join(', ')} comparisons with numeric values`);
                 }
+
+                this.buildAggregateRelationQuery(qb, statements, reference, mode, groupedRelations[key].joinFilterStatements);
             }
         });
     }

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -594,6 +594,14 @@ class MongoToKnex {
         const baseTable = config.tableNameAs || config.tableName;
         const baseTableValue = config.tableNameAs ? `${config.tableName} as ${config.tableNameAs}` : config.tableName;
 
+        // CASE: $and groups attach every join table filter of the group to every
+        //       relation subquery - only filters on tables that are part of this
+        //       subquery's join chain can restrict the aggregated rows, the others
+        //       reference tables that are never joined here and are handled by their
+        //       own relation's subquery
+        const subqueryTables = [baseTable, ..._.map(config.joins, join => join.tableNameAs || join.tableName)];
+        const applicableJoinFilters = _.filter(joinFilterStatements, joinFilter => subqueryTables.includes(joinFilter.joinTable));
+
         // CASE: WHERE resource.id (IN | NOT IN) (SELECT ... GROUP BY ... HAVING ...)
         qb[whereType](`${this.tableName}.id`, comp, function () {
             const innerQB = this
@@ -626,7 +634,7 @@ class MongoToKnex {
 
             // CASE: when applying AND conjunction, filters on a join table restrict
             //       which related rows are aggregated (same as the other relation types)
-            _.each(joinFilterStatements, (joinFilter) => {
+            _.each(applicableJoinFilters, (joinFilter) => {
                 innerQB.where(`${joinFilter.joinTable}.${joinFilter.column}`, compOps[joinFilter.operator], joinFilter.value);
             });
 

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -261,9 +261,15 @@ class MongoToKnex {
              * - e.g. $and conjunction requires us to use 2 sub queries, because we have to look at each individual tag
              *
              * - we should also not use grouping of negated values for the same reasons as above
+             *
+             * - aggregate relations are the exception: every condition compares the same single
+             *   computed value per parent row, so all conditions belong in one subquery with a
+             *   combined HAVING - the "must match a different row" reasoning doesn't apply
              */
-            let shouldCreateSubGroup = isNegationOp(statement.operator);
-            if (!shouldCreateSubGroup && group[statement.table]) {
+            const isAggregate = statement.config && statement.config.type === 'aggregate';
+
+            let shouldCreateSubGroup = !isAggregate && isNegationOp(statement.operator);
+            if (!shouldCreateSubGroup && !isAggregate && group[statement.table]) {
                 shouldCreateSubGroup = _.some(group[statement.table].innerWhereStatements, (innerStatement) => {
                     if (innerStatement.column !== statement.column) {
                         return false;

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -36,14 +36,13 @@ const complementOps = {
     $nin: '$in'
 };
 
-// SQL templates for the supported aggregate functions, ?? is bound to the configured column
+// SQL templates for the supported aggregate functions, ?? is bound to the configured column.
+// Only functions where "no related rows" is equivalent to an aggregate value of 0 are
+// supported - min/max/avg are NULL over no rows, which would break the zero-count inversion
 const aggregateFunctions = {
     count: 'count(??)',
     countDistinct: 'count(distinct ??)',
-    sum: 'sum(??)',
-    avg: 'avg(??)',
-    min: 'min(??)',
-    max: 'max(??)'
+    sum: 'sum(??)'
 };
 
 // We don't use a backslash as escpae character, because knex reescapes backslashes in binded parameters

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -71,6 +71,9 @@ const isAggregateValue = (op, value) => {
 //eslint-disable-next-line ghost/ghost-custom/no-native-error
 const aggregateOperatorError = relationName => new Error(`Aggregate relation "${relationName}" only supports ${Object.keys(complementOps).join(', ')} comparisons with numeric values`);
 
+//eslint-disable-next-line ghost/ghost-custom/no-native-error
+const aggregateColumnError = relationName => new Error(`Aggregate relation "${relationName}" is queried by name only, without a column (e.g. "${relationName}:0")`);
+
 /**
  * Whether an aggregate comparison would match a parent row with no related rows
  * (aggregate value 0). Such rows don't appear in the grouped subquery at all, so
@@ -202,8 +205,7 @@ class MongoToKnex {
             //       column to select - a dotted suffix is meaningless and only invites
             //       aliased spellings of the same query, so it's rejected outright
             if (relation && relation.type === 'aggregate') {
-                //eslint-disable-next-line ghost/ghost-custom/no-native-error
-                throw new Error(`Aggregate relation "${table}" is queried by name only, without a column (e.g. "${table}:0")`);
+                throw aggregateColumnError(table);
             }
 
             if (!relation) {
@@ -541,15 +543,8 @@ class MongoToKnex {
                     debug(`one of ${key} group statements contains unknown operator`);
                 }
             } else if (reference.config.type === 'aggregate') {
-                // CASE: unlike the other relation types we throw instead of silently dropping
-                //       the group - a dropped statement widens the result set, returning rows
-                //       the filter was meant to exclude
-                const invalidStatement = statements.find(s => !isAggregateCompOp(s.operator) || !isAggregateValue(s.operator, s.value));
-
-                if (invalidStatement) {
-                    throw aggregateOperatorError(invalidStatement.table);
-                }
-
+                // NOTE: operators and values were already validated by the
+                //       validateAggregateStatements pre-pass in processJSON
                 this.buildAggregateRelationQuery(qb, statements, reference, mode, groupedRelations[key].joinFilterStatements);
             }
         });
@@ -747,21 +742,12 @@ class MongoToKnex {
         }
 
         // CASE: sub is an object, contains statements and operators
+        //       (unknown operators on aggregate relations were already rejected by
+        //       the validateAggregateStatements pre-pass in processJSON)
         _.forIn(sub, (value, op) => {
             if (isCompOp(op)) {
                 this.buildComparison(qb, mode, statement, op, value, group);
             } else {
-                // CASE: unknown operators are dropped, but for aggregate relations a
-                //       dropped statement widens the result set, so they fail closed -
-                //       this has to happen here because dropped statements never reach
-                //       the aggregate validation in buildRelationQuery
-                const [relationName] = statement.split('.');
-                const relation = this.config.relations[relationName];
-
-                if (relation && relation.type === 'aggregate') {
-                    throw aggregateOperatorError(relationName);
-                }
-
                 debug('unknown operator');
             }
         });
@@ -816,6 +802,57 @@ class MongoToKnex {
     }
 
     /**
+     * Validate every aggregate statement before any query is built. Unlike the other
+     * relation types invalid aggregate statements throw instead of being silently
+     * dropped - a dropped statement widens the result set, returning rows the filter
+     * was meant to exclude.
+     *
+     * Validation is a separate pre-pass because grouped statements ($and/$or) are
+     * built inside knex where-callbacks, which only run once the query is rendered -
+     * a throw from there surfaces after query building has finished, escaping any
+     * error handling wrapped around it (e.g. the layer turning invalid filters into
+     * 4xx responses).
+     */
+    validateAggregateStatements(sub) {
+        if (!_.isPlainObject(sub)) {
+            return;
+        }
+
+        _.forIn(sub, (value, key) => {
+            if (isLogicOp(key)) {
+                _.castArray(value).forEach(group => this.validateAggregateStatements(group));
+                return;
+            }
+
+            if (isOp(key)) {
+                return;
+            }
+
+            const [relationName, columnName] = key.split('.');
+            const relation = this.config.relations[relationName];
+
+            if (!relation || relation.type !== 'aggregate') {
+                return;
+            }
+
+            // CASE: same rejection as processStatement, raised here so it fires
+            //       before query building for grouped statements too
+            if (columnName) {
+                throw aggregateColumnError(relationName);
+            }
+
+            // CASE: an atomic value (incl. arrays and regexes) is shorthand for $eq
+            const statements = _.isPlainObject(value) ? value : {$eq: value};
+
+            _.forIn(statements, (statementValue, op) => {
+                if (!isAggregateCompOp(op) || !isAggregateValue(op, statementValue)) {
+                    throw aggregateOperatorError(relationName);
+                }
+            });
+        });
+    }
+
+    /**
      * The converter receives sub query objects e.g. `qb.where('..', (qb) => {})`, which
      * we then pass around to our class methods. That's why we pass the parent `qb` object
      * around instead of remembering it as `this.qb`. There are multiple `qb` objects.
@@ -827,6 +864,8 @@ class MongoToKnex {
         if (debugExtended.enabled) {
             debugExtended(`(processJSON) ${stringify(mongoJSON)}`);
         }
+
+        this.validateAggregateStatements(mongoJSON);
 
         // 'and' is the default behaviour
         this.buildQuery(qb, '$and', mongoJSON);

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -56,10 +56,20 @@ const isAggregateCompOp = key => Boolean(complementOps[key]);
 
 // Aggregate values must be numeric: the inversion decision below evaluates the predicate
 // at 0 in JS, so a value the database would coerce differently (null, '', '2abc') must be
-// rejected up front or the two evaluations can disagree
+// rejected up front or the two evaluations can disagree. Arrays are only meaningful for
+// the set operators - bound to a scalar comparison they render invalid SQL (e.g. `> 1, 2`)
 const isNumericScalar = value => (_.isNumber(value) && Number.isFinite(value))
     || (_.isString(value) && value.trim() !== '' && Number.isFinite(Number(value)));
-const isAggregateValue = value => (_.isArray(value) ? _.every(value, isNumericScalar) : isNumericScalar(value));
+const isAggregateValue = (op, value) => {
+    if (op === '$in' || op === '$nin') {
+        return _.isArray(value) ? _.every(value, isNumericScalar) : isNumericScalar(value);
+    }
+
+    return isNumericScalar(value);
+};
+
+//eslint-disable-next-line ghost/ghost-custom/no-native-error
+const aggregateOperatorError = relationName => new Error(`Aggregate relation "${relationName}" only supports ${Object.keys(complementOps).join(', ')} comparisons with numeric values`);
 
 /**
  * Whether an aggregate comparison would match a parent row with no related rows
@@ -534,11 +544,10 @@ class MongoToKnex {
                 // CASE: unlike the other relation types we throw instead of silently dropping
                 //       the group - a dropped statement widens the result set, returning rows
                 //       the filter was meant to exclude
-                const invalidStatement = statements.find(s => !isAggregateCompOp(s.operator) || !isAggregateValue(s.value));
+                const invalidStatement = statements.find(s => !isAggregateCompOp(s.operator) || !isAggregateValue(s.operator, s.value));
 
                 if (invalidStatement) {
-                    //eslint-disable-next-line ghost/ghost-custom/no-native-error
-                    throw new Error(`Aggregate relation "${invalidStatement.table}" only supports ${Object.keys(complementOps).join(', ')} comparisons with numeric values`);
+                    throw aggregateOperatorError(invalidStatement.table);
                 }
 
                 this.buildAggregateRelationQuery(qb, statements, reference, mode, groupedRelations[key].joinFilterStatements);
@@ -742,6 +751,17 @@ class MongoToKnex {
             if (isCompOp(op)) {
                 this.buildComparison(qb, mode, statement, op, value, group);
             } else {
+                // CASE: unknown operators are dropped, but for aggregate relations a
+                //       dropped statement widens the result set, so they fail closed -
+                //       this has to happen here because dropped statements never reach
+                //       the aggregate validation in buildRelationQuery
+                const [relationName] = statement.split('.');
+                const relation = this.config.relations[relationName];
+
+                if (relation && relation.type === 'aggregate') {
+                    throw aggregateOperatorError(relationName);
+                }
+
                 debug('unknown operator');
             }
         });

--- a/packages/mongo-knex/test/integration/relations.test.js
+++ b/packages/mongo-knex/test/integration/relations.test.js
@@ -1661,6 +1661,13 @@ describe('Relations', function () {
         //       Public tag counts per post (post 8's only tag is internal): 1:1, 2:1, 3:1, 4:2, 5:1, 6:2, 7:0, 8:0
         //       Author counts per post: 1:1, 2:1, 3:1, 4:2, 5:1, 6:1, 7:1, 8:2
 
+        // CASE: an orphaned join table row (NULL post_id) must not poison the inverted
+        //       NOT IN subqueries - without a NOT NULL guard a single NULL in the
+        //       subquery result makes every zero-matching query return no rows
+        before(function () {
+            return knex('posts_tags').insert({post_id: null, tag_id: 3});
+        });
+
         describe('EQUALS $eq', function () {
             it('tag_count.count equals 2', function () {
                 const mongoJSON = {
@@ -2064,6 +2071,31 @@ describe('Relations', function () {
                     .then((result) => {
                         result.should.be.an.Array().with.lengthOf(1);
                         result.should.matchIds([4]);
+                    });
+            });
+
+            it('combined with a join table filter, restricting the aggregated rows', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'posts_tags.sort_order': 1
+                        },
+                        {
+                            'tag_count.count': {
+                                $gt: 0
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        // only posts 4, 6 and 8 have a tag attached with sort_order 1
+                        result.should.be.an.Array().with.lengthOf(3);
+                        result.should.matchIds([4, 6, 8]);
                     });
             });
         });

--- a/packages/mongo-knex/test/integration/relations.test.js
+++ b/packages/mongo-knex/test/integration/relations.test.js
@@ -52,6 +52,15 @@ const makeQuery = (mongoJSON) => {
                 joins: [{tableName: 'tags', from: 'id', to: 'tag_id'}],
                 wheres: {'tags.visibility': 'public'}
             },
+            aliased_public_tag_count: {
+                type: 'aggregate',
+                aggregate: {fn: 'countDistinct', column: 'pt.tag_id'},
+                tableName: 'posts_tags',
+                tableNameAs: 'pt',
+                joinFrom: 'post_id',
+                joins: [{tableName: 'tags', tableNameAs: 't', from: 'id', to: 'tag_id'}],
+                wheres: {'t.visibility': 'public'}
+            },
             author_count: {
                 type: 'aggregate',
                 aggregate: {fn: 'countDistinct', column: 'posts_authors.author_id'},
@@ -2263,6 +2272,38 @@ describe('Relations', function () {
             it('public_tag_count.count equals 0 includes posts with only non-qualifying rows', function () {
                 const mongoJSON = {
                     'public_tag_count.count': 0
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result.should.matchIds([7, 8]);
+                    });
+            });
+
+            it('aliased tables return the same results as unaliased', function () {
+                const mongoJSON = {
+                    'aliased_public_tag_count.count': {
+                        $gt: 1
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result.should.matchIds([4, 6]);
+                    });
+            });
+
+            it('aliased tables return the same results as unaliased when inverted', function () {
+                const mongoJSON = {
+                    'aliased_public_tag_count.count': 0
                 };
 
                 const query = makeQuery(mongoJSON);

--- a/packages/mongo-knex/test/integration/relations.test.js
+++ b/packages/mongo-knex/test/integration/relations.test.js
@@ -2191,6 +2191,37 @@ describe('Relations', function () {
                         result.should.matchIds([4, 6, 8]);
                     });
             });
+
+            it('combined with a join table filter belonging to another relation', function () {
+                // posts_authors is the authors relation's join table - it must restrict
+                // the authors subquery only, the tag_count subquery never joins it
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'authors.slug': 'pat'
+                        },
+                        {
+                            'posts_authors.sort_order': 1
+                        },
+                        {
+                            tag_count: {
+                                $gt: 1
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        // pat is attached with sort_order 1 to post 4 only,
+                        // posts 4 and 6 have more than one tag
+                        result.should.be.an.Array().with.lengthOf(1);
+                        result.should.matchIds([4]);
+                    });
+            });
         });
 
         describe('OR $or', function () {

--- a/packages/mongo-knex/test/integration/relations.test.js
+++ b/packages/mongo-knex/test/integration/relations.test.js
@@ -37,6 +37,32 @@ const makeQuery = (mongoJSON) => {
                 joinFrom: 'post_id',
                 joinTo: 'comment_id',
                 joinToForeign: 'comment_provider_id'
+            },
+            tag_count: {
+                type: 'aggregate',
+                aggregate: {fn: 'count', column: 'posts_tags.tag_id'},
+                tableName: 'posts_tags',
+                joinFrom: 'post_id'
+            },
+            public_tag_count: {
+                type: 'aggregate',
+                aggregate: {fn: 'countDistinct', column: 'posts_tags.tag_id'},
+                tableName: 'posts_tags',
+                joinFrom: 'post_id',
+                joins: [{tableName: 'tags', from: 'id', to: 'tag_id'}],
+                wheres: {'tags.visibility': 'public'}
+            },
+            author_count: {
+                type: 'aggregate',
+                aggregate: {fn: 'countDistinct', column: 'posts_authors.author_id'},
+                tableName: 'posts_authors',
+                joinFrom: 'post_id'
+            },
+            tag_sort_order_total: {
+                type: 'aggregate',
+                aggregate: {fn: 'sum', column: 'posts_tags.sort_order'},
+                tableName: 'posts_tags',
+                joinFrom: 'post_id'
             }
         }
     });
@@ -1058,36 +1084,6 @@ describe('Relations', function () {
                     });
             });
         });
-
-        describe('COUNT', function () {
-            it.skip('can compare by count $gt', function () {
-                const mongoJSON = {
-                    'authors.count': {$gt: 0}
-                };
-
-                const query = makeQuery(mongoJSON);
-
-                return query
-                    .select()
-                    .then((result) => {
-                        result.should.be.an.Array().with.lengthOf(3);
-                    });
-            });
-
-            it.skip('can compare by count $lt', function () {
-                const mongoJSON = {
-                    'authors.count': {$lt: 2}
-                };
-
-                const query = makeQuery(mongoJSON);
-
-                return query
-                    .select()
-                    .then((result) => {
-                        result.should.be.an.Array().with.lengthOf(3);
-                    });
-            });
-        });
     });
 
     describe('One-to-One', function () {
@@ -1654,6 +1650,603 @@ describe('Relations', function () {
                     .then((result) => {
                         result.should.be.an.Array().with.lengthOf(2);
                         result.should.matchIds([1, 2]);
+                    });
+            });
+        });
+    });
+
+    describe('Aggregate', function () {
+        // NOTE: these tests rely on the fixtures loaded by the Many-to-Many suite above.
+        //       Tag counts per post: 1:1, 2:1, 3:1, 4:2, 5:1, 6:2, 7:0, 8:1
+        //       Public tag counts per post (post 8's only tag is internal): 1:1, 2:1, 3:1, 4:2, 5:1, 6:2, 7:0, 8:0
+        //       Author counts per post: 1:1, 2:1, 3:1, 4:2, 5:1, 6:1, 7:1, 8:2
+
+        describe('EQUALS $eq', function () {
+            it('tag_count.count equals 2', function () {
+                const mongoJSON = {
+                    'tag_count.count': 2
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result.should.matchIds([4, 6]);
+                    });
+            });
+
+            it('tag_count.count equals 1', function () {
+                const mongoJSON = {
+                    'tag_count.count': 1
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(5);
+                        result.should.matchIds([1, 2, 3, 5, 8]);
+                    });
+            });
+
+            it('tag_count.count equals 0 includes posts with no tags', function () {
+                const mongoJSON = {
+                    'tag_count.count': 0
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(1);
+                        result.should.matchIds([7]);
+                    });
+            });
+        });
+
+        describe('NEGATION $ne', function () {
+            it('tag_count.count is NOT 1 includes posts with no tags', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $ne: 1
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(3);
+                        result.should.matchIds([4, 6, 7]);
+                    });
+            });
+
+            it('tag_count.count is NOT 0 excludes posts with no tags', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $ne: 0
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(7);
+                        result.should.matchIds([1, 2, 3, 4, 5, 6, 8]);
+                    });
+            });
+        });
+
+        describe('COMPARISONS $gt / $gte / $lt / $lte', function () {
+            it('tag_count.count is > 1', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $gt: 1
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result.should.matchIds([4, 6]);
+                    });
+            });
+
+            it('tag_count.count is >= 1', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $gte: 1
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(7);
+                        result.should.matchIds([1, 2, 3, 4, 5, 6, 8]);
+                    });
+            });
+
+            it('tag_count.count is >= 0 matches all posts', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $gte: 0
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(8);
+                        result.should.matchIds([1, 2, 3, 4, 5, 6, 7, 8]);
+                    });
+            });
+
+            it('tag_count.count is < 2 includes posts with no tags', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $lt: 2
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(6);
+                        result.should.matchIds([1, 2, 3, 5, 7, 8]);
+                    });
+            });
+
+            it('tag_count.count is < 1 only matches posts with no tags', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $lt: 1
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(1);
+                        result.should.matchIds([7]);
+                    });
+            });
+
+            it('tag_count.count is <= 1 includes posts with no tags', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $lte: 1
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(6);
+                        result.should.matchIds([1, 2, 3, 5, 7, 8]);
+                    });
+            });
+        });
+
+        describe('IN $in', function () {
+            it('tag_count.count is in [1, 2]', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $in: [1, 2]
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(7);
+                        result.should.matchIds([1, 2, 3, 4, 5, 6, 8]);
+                    });
+            });
+
+            it('tag_count.count is in [0, 2] includes posts with no tags', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $in: [0, 2]
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(3);
+                        result.should.matchIds([4, 6, 7]);
+                    });
+            });
+        });
+
+        describe('NOT IN $nin', function () {
+            it('tag_count.count is NOT in [1] includes posts with no tags', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $nin: [1]
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(3);
+                        result.should.matchIds([4, 6, 7]);
+                    });
+            });
+
+            it('tag_count.count is NOT in [0, 1] excludes posts with no tags', function () {
+                const mongoJSON = {
+                    'tag_count.count': {
+                        $nin: [0, 1]
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result.should.matchIds([4, 6]);
+                    });
+            });
+        });
+
+        describe('AND $and', function () {
+            it('range conditions on the same aggregate combine in one subquery', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'tag_count.count': {
+                                $gt: 0
+                            }
+                        },
+                        {
+                            'tag_count.count': {
+                                $lt: 2
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(5);
+                        result.should.matchIds([1, 2, 3, 5, 8]);
+                    });
+            });
+
+            it('combined with a many-to-many relation', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'tags.slug': 'animal'
+                        },
+                        {
+                            'tag_count.count': {
+                                $gt: 1
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result.should.matchIds([4, 6]);
+                    });
+            });
+
+            it('negated aggregate combined with a many-to-many relation', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'tag_count.count': {
+                                $ne: 1
+                            }
+                        },
+                        {
+                            'tags.slug': 'animal'
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result.should.matchIds([4, 6]);
+                    });
+            });
+
+            it('combined with a one-to-one relation', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'posts_meta.like_count': 42
+                        },
+                        {
+                            'tag_count.count': {
+                                $gt: 1
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(1);
+                        result.should.matchIds([4]);
+                    });
+            });
+
+            it('combined with a column on the parent table', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            featured: true
+                        },
+                        {
+                            'tag_count.count': 0
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(1);
+                        result.should.matchIds([7]);
+                    });
+            });
+
+            it('combined with another aggregate relation', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'tag_count.count': {
+                                $gt: 1
+                            }
+                        },
+                        {
+                            'author_count.count': {
+                                $gt: 1
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(1);
+                        result.should.matchIds([4]);
+                    });
+            });
+        });
+
+        describe('OR $or', function () {
+            it('zero count or high count', function () {
+                const mongoJSON = {
+                    $or: [
+                        {
+                            'tag_count.count': 0
+                        },
+                        {
+                            'tag_count.count': {
+                                $gt: 1
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(3);
+                        result.should.matchIds([4, 6, 7]);
+                    });
+            });
+
+            it('range conditions on the same aggregate (inverted group)', function () {
+                const mongoJSON = {
+                    $or: [
+                        {
+                            'tag_count.count': {
+                                $lt: 1
+                            }
+                        },
+                        {
+                            'tag_count.count': {
+                                $gt: 1
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(3);
+                        result.should.matchIds([4, 6, 7]);
+                    });
+            });
+
+            it('combined with a column on the parent table', function () {
+                const mongoJSON = {
+                    $or: [
+                        {
+                            status: 'draft'
+                        },
+                        {
+                            'tag_count.count': {
+                                $gt: 1
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(3);
+                        result.should.matchIds([2, 4, 6]);
+                    });
+            });
+
+            it('combined with a many-to-many relation', function () {
+                const mongoJSON = {
+                    $or: [
+                        {
+                            'tags.slug': 'cgi'
+                        },
+                        {
+                            'tag_count.count': {
+                                $gt: 1
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(3);
+                        result.should.matchIds([3, 4, 6]);
+                    });
+            });
+        });
+
+        describe('config-driven joins and wheres', function () {
+            it('public_tag_count.count is > 1 only counts qualifying rows', function () {
+                const mongoJSON = {
+                    'public_tag_count.count': {
+                        $gt: 1
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result.should.matchIds([4, 6]);
+                    });
+            });
+
+            it('public_tag_count.count equals 1', function () {
+                const mongoJSON = {
+                    'public_tag_count.count': 1
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(4);
+                        result.should.matchIds([1, 2, 3, 5]);
+                    });
+            });
+
+            it('public_tag_count.count equals 0 includes posts with only non-qualifying rows', function () {
+                const mongoJSON = {
+                    'public_tag_count.count': 0
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result.should.matchIds([7, 8]);
+                    });
+            });
+        });
+
+        describe('SUM', function () {
+            it('tag_sort_order_total.sum is > 0', function () {
+                const mongoJSON = {
+                    'tag_sort_order_total.sum': {
+                        $gt: 0
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(3);
+                        result.should.matchIds([4, 6, 8]);
+                    });
+            });
+
+            it('tag_sort_order_total.sum equals 0 includes posts with no related rows and rows summing to zero', function () {
+                const mongoJSON = {
+                    'tag_sort_order_total.sum': 0
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(5);
+                        result.should.matchIds([1, 2, 3, 5, 7]);
                     });
             });
         });

--- a/packages/mongo-knex/test/integration/relations.test.js
+++ b/packages/mongo-knex/test/integration/relations.test.js
@@ -1936,6 +1936,63 @@ describe('Relations', function () {
             });
         });
 
+        describe('numeric strings', function () {
+            // CASE: numeric strings must match the same rows as their numeric value -
+            //       bound as strings the comparison silently diverges from the JS-side
+            //       inversion decision (SQLite never coerces: an integer aggregate
+            //       always sorts below any string, so e.g. < '2' matched every post)
+            it('tag_count is < "2" matches the same rows as the numeric value (inverted)', function () {
+                const mongoJSON = {
+                    tag_count: {
+                        $lt: '2'
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(6);
+                        result.should.matchIds([1, 2, 3, 5, 7, 8]);
+                    });
+            });
+
+            it('tag_count is > "1" matches the same rows as the numeric value', function () {
+                const mongoJSON = {
+                    tag_count: {
+                        $gt: '1'
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result.should.matchIds([4, 6]);
+                    });
+            });
+
+            it('tag_count is in ["1", "2"] matches the same rows as the numeric values', function () {
+                const mongoJSON = {
+                    tag_count: {
+                        $in: ['1', '2']
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(7);
+                        result.should.matchIds([1, 2, 3, 4, 5, 6, 8]);
+                    });
+            });
+        });
+
         describe('AND $and', function () {
             it('range conditions on the same aggregate combine in one subquery', function () {
                 const mongoJSON = {

--- a/packages/mongo-knex/test/integration/relations.test.js
+++ b/packages/mongo-knex/test/integration/relations.test.js
@@ -1954,6 +1954,33 @@ describe('Relations', function () {
                     });
             });
 
+            it('negated and range conditions on the same aggregate combine in one subquery', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'tag_count.count': {
+                                $ne: 1
+                            }
+                        },
+                        {
+                            'tag_count.count': {
+                                $lt: 5
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        // posts with 0 or 2 tags
+                        result.should.be.an.Array().with.lengthOf(3);
+                        result.should.matchIds([4, 6, 7]);
+                    });
+            });
+
             it('combined with a many-to-many relation', function () {
                 const mongoJSON = {
                     $and: [

--- a/packages/mongo-knex/test/integration/relations.test.js
+++ b/packages/mongo-knex/test/integration/relations.test.js
@@ -1678,9 +1678,9 @@ describe('Relations', function () {
         });
 
         describe('EQUALS $eq', function () {
-            it('tag_count.count equals 2', function () {
+            it('tag_count equals 2', function () {
                 const mongoJSON = {
-                    'tag_count.count': 2
+                    tag_count: 2
                 };
 
                 const query = makeQuery(mongoJSON);
@@ -1693,9 +1693,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('tag_count.count equals 1', function () {
+            it('tag_count equals 1', function () {
                 const mongoJSON = {
-                    'tag_count.count': 1
+                    tag_count: 1
                 };
 
                 const query = makeQuery(mongoJSON);
@@ -1708,9 +1708,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('tag_count.count equals 0 includes posts with no tags', function () {
+            it('tag_count equals 0 includes posts with no tags', function () {
                 const mongoJSON = {
-                    'tag_count.count': 0
+                    tag_count: 0
                 };
 
                 const query = makeQuery(mongoJSON);
@@ -1725,9 +1725,9 @@ describe('Relations', function () {
         });
 
         describe('NEGATION $ne', function () {
-            it('tag_count.count is NOT 1 includes posts with no tags', function () {
+            it('tag_count is NOT 1 includes posts with no tags', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $ne: 1
                     }
                 };
@@ -1742,9 +1742,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('tag_count.count is NOT 0 excludes posts with no tags', function () {
+            it('tag_count is NOT 0 excludes posts with no tags', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $ne: 0
                     }
                 };
@@ -1761,9 +1761,9 @@ describe('Relations', function () {
         });
 
         describe('COMPARISONS $gt / $gte / $lt / $lte', function () {
-            it('tag_count.count is > 1', function () {
+            it('tag_count is > 1', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $gt: 1
                     }
                 };
@@ -1778,9 +1778,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('tag_count.count is >= 1', function () {
+            it('tag_count is >= 1', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $gte: 1
                     }
                 };
@@ -1795,9 +1795,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('tag_count.count is >= 0 matches all posts', function () {
+            it('tag_count is >= 0 matches all posts', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $gte: 0
                     }
                 };
@@ -1812,9 +1812,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('tag_count.count is < 2 includes posts with no tags', function () {
+            it('tag_count is < 2 includes posts with no tags', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $lt: 2
                     }
                 };
@@ -1829,9 +1829,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('tag_count.count is < 1 only matches posts with no tags', function () {
+            it('tag_count is < 1 only matches posts with no tags', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $lt: 1
                     }
                 };
@@ -1846,9 +1846,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('tag_count.count is <= 1 includes posts with no tags', function () {
+            it('tag_count is <= 1 includes posts with no tags', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $lte: 1
                     }
                 };
@@ -1865,9 +1865,9 @@ describe('Relations', function () {
         });
 
         describe('IN $in', function () {
-            it('tag_count.count is in [1, 2]', function () {
+            it('tag_count is in [1, 2]', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $in: [1, 2]
                     }
                 };
@@ -1882,9 +1882,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('tag_count.count is in [0, 2] includes posts with no tags', function () {
+            it('tag_count is in [0, 2] includes posts with no tags', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $in: [0, 2]
                     }
                 };
@@ -1901,9 +1901,9 @@ describe('Relations', function () {
         });
 
         describe('NOT IN $nin', function () {
-            it('tag_count.count is NOT in [1] includes posts with no tags', function () {
+            it('tag_count is NOT in [1] includes posts with no tags', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $nin: [1]
                     }
                 };
@@ -1918,9 +1918,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('tag_count.count is NOT in [0, 1] excludes posts with no tags', function () {
+            it('tag_count is NOT in [0, 1] excludes posts with no tags', function () {
                 const mongoJSON = {
-                    'tag_count.count': {
+                    tag_count: {
                         $nin: [0, 1]
                     }
                 };
@@ -1941,12 +1941,12 @@ describe('Relations', function () {
                 const mongoJSON = {
                     $and: [
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $gt: 0
                             }
                         },
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $lt: 2
                             }
                         }
@@ -1967,12 +1967,12 @@ describe('Relations', function () {
                 const mongoJSON = {
                     $and: [
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $ne: 1
                             }
                         },
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $lt: 5
                             }
                         }
@@ -1997,7 +1997,7 @@ describe('Relations', function () {
                             'tags.slug': 'animal'
                         },
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $gt: 1
                             }
                         }
@@ -2018,7 +2018,7 @@ describe('Relations', function () {
                 const mongoJSON = {
                     $and: [
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $ne: 1
                             }
                         },
@@ -2045,7 +2045,7 @@ describe('Relations', function () {
                             'posts_meta.like_count': 42
                         },
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $gt: 1
                             }
                         }
@@ -2069,7 +2069,7 @@ describe('Relations', function () {
                             featured: true
                         },
                         {
-                            'tag_count.count': 0
+                            tag_count: 0
                         }
                     ]
                 };
@@ -2088,12 +2088,12 @@ describe('Relations', function () {
                 const mongoJSON = {
                     $and: [
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $gt: 1
                             }
                         },
                         {
-                            'author_count.count': {
+                            author_count: {
                                 $gt: 1
                             }
                         }
@@ -2117,7 +2117,7 @@ describe('Relations', function () {
                             'posts_tags.sort_order': 1
                         },
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $gt: 0
                             }
                         }
@@ -2141,10 +2141,10 @@ describe('Relations', function () {
                 const mongoJSON = {
                     $or: [
                         {
-                            'tag_count.count': 0
+                            tag_count: 0
                         },
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $gt: 1
                             }
                         }
@@ -2165,12 +2165,12 @@ describe('Relations', function () {
                 const mongoJSON = {
                     $or: [
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $lt: 1
                             }
                         },
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $gt: 1
                             }
                         }
@@ -2194,7 +2194,7 @@ describe('Relations', function () {
                             status: 'draft'
                         },
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $gt: 1
                             }
                         }
@@ -2218,7 +2218,7 @@ describe('Relations', function () {
                             'tags.slug': 'cgi'
                         },
                         {
-                            'tag_count.count': {
+                            tag_count: {
                                 $gt: 1
                             }
                         }
@@ -2237,9 +2237,9 @@ describe('Relations', function () {
         });
 
         describe('config-driven joins and wheres', function () {
-            it('public_tag_count.count is > 1 only counts qualifying rows', function () {
+            it('public_tag_count is > 1 only counts qualifying rows', function () {
                 const mongoJSON = {
-                    'public_tag_count.count': {
+                    public_tag_count: {
                         $gt: 1
                     }
                 };
@@ -2254,9 +2254,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('public_tag_count.count equals 1', function () {
+            it('public_tag_count equals 1', function () {
                 const mongoJSON = {
-                    'public_tag_count.count': 1
+                    public_tag_count: 1
                 };
 
                 const query = makeQuery(mongoJSON);
@@ -2269,9 +2269,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('public_tag_count.count equals 0 includes posts with only non-qualifying rows', function () {
+            it('public_tag_count equals 0 includes posts with only non-qualifying rows', function () {
                 const mongoJSON = {
-                    'public_tag_count.count': 0
+                    public_tag_count: 0
                 };
 
                 const query = makeQuery(mongoJSON);
@@ -2286,7 +2286,7 @@ describe('Relations', function () {
 
             it('aliased tables return the same results as unaliased', function () {
                 const mongoJSON = {
-                    'aliased_public_tag_count.count': {
+                    aliased_public_tag_count: {
                         $gt: 1
                     }
                 };
@@ -2303,7 +2303,7 @@ describe('Relations', function () {
 
             it('aliased tables return the same results as unaliased when inverted', function () {
                 const mongoJSON = {
-                    'aliased_public_tag_count.count': 0
+                    aliased_public_tag_count: 0
                 };
 
                 const query = makeQuery(mongoJSON);
@@ -2318,9 +2318,9 @@ describe('Relations', function () {
         });
 
         describe('SUM', function () {
-            it('tag_sort_order_total.sum is > 0', function () {
+            it('tag_sort_order_total is > 0', function () {
                 const mongoJSON = {
-                    'tag_sort_order_total.sum': {
+                    tag_sort_order_total: {
                         $gt: 0
                     }
                 };
@@ -2335,9 +2335,9 @@ describe('Relations', function () {
                     });
             });
 
-            it('tag_sort_order_total.sum equals 0 includes posts with no related rows and rows summing to zero', function () {
+            it('tag_sort_order_total equals 0 includes posts with no related rows and rows summing to zero', function () {
                 const mongoJSON = {
-                    'tag_sort_order_total.sum': 0
+                    tag_sort_order_total: 0
                 };
 
                 const query = makeQuery(mongoJSON);

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -23,6 +23,20 @@ const runQuery = query => convertor(knex('posts'), query, {
             tableName: 'posts_meta',
             type: 'oneToOne',
             joinFrom: 'post_id'
+        },
+        tag_count: {
+            type: 'aggregate',
+            aggregate: {fn: 'count', column: 'posts_tags.tag_id'},
+            tableName: 'posts_tags',
+            joinFrom: 'post_id'
+        },
+        public_tag_count: {
+            type: 'aggregate',
+            aggregate: {fn: 'countDistinct', column: 'posts_tags.tag_id'},
+            tableName: 'posts_tags',
+            joinFrom: 'post_id',
+            joins: [{tableName: 'tags', from: 'id', to: 'tag_id'}],
+            wheres: {'tags.visibility': 'public'}
         }
     }
 }).toQuery();
@@ -434,6 +448,145 @@ describe('Relations', function () {
     it('should be able to perform a negated query on a one-to-one relation (works but is weird)', function () {
         runQuery({'posts_meta.meta_title': {$ne: 'Meta of A Whole New World'}})
             .should.eql('select * from `posts` where `posts`.`id` not in (select `posts`.`id` from `posts` left join `posts_meta` on `posts_meta`.`post_id` = `posts`.`id` where `posts_meta`.`meta_title` in (\'Meta of A Whole New World\'))');
+    });
+});
+
+describe('Aggregate Relations', function () {
+    describe('operators not matching a zero aggregate use IN + HAVING as stated', function () {
+        it('$eq with a non-zero value', function () {
+            runQuery({'tag_count.count': 2})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) = 2)');
+        });
+
+        it('$ne 0', function () {
+            runQuery({'tag_count.count': {$ne: 0}})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0)');
+        });
+
+        it('$gt', function () {
+            runQuery({'tag_count.count': {$gt: 1}})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1)');
+        });
+
+        it('$gte with a non-zero value', function () {
+            runQuery({'tag_count.count': {$gte: 1}})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 1)');
+        });
+
+        it('$in without zero', function () {
+            runQuery({'tag_count.count': {$in: [1, 2]}})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) in (1, 2))');
+        });
+
+        it('$nin containing zero', function () {
+            runQuery({'tag_count.count': {$nin: [0]}})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) not in (0))');
+        });
+    });
+
+    describe('operators matching a zero aggregate are inverted to NOT IN + complement HAVING', function () {
+        it('$eq 0', function () {
+            runQuery({'tag_count.count': 0})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0)');
+        });
+
+        it('$ne with a non-zero value', function () {
+            runQuery({'tag_count.count': {$ne: 1}})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) = 1)');
+        });
+
+        it('$lt', function () {
+            runQuery({'tag_count.count': {$lt: 2}})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 2)');
+        });
+
+        it('$lte 0', function () {
+            runQuery({'tag_count.count': {$lte: 0}})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 0)');
+        });
+
+        it('$gte 0 (matches everything)', function () {
+            runQuery({'tag_count.count': {$gte: 0}})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) < 0)');
+        });
+
+        it('$in containing zero', function () {
+            runQuery({'tag_count.count': {$in: [0, 2]}})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) not in (0, 2))');
+        });
+
+        it('$nin without zero', function () {
+            runQuery({'tag_count.count': {$nin: [1]}})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) in (1))');
+        });
+    });
+
+    describe('grouping', function () {
+        it('combines $and range conditions on the same aggregate into a single subquery', function () {
+            runQuery({$and: [{'tag_count.count': {$gt: 1}}, {'tag_count.count': {$lt: 5}}]})
+                .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1 and count(`posts_tags`.`tag_id`) < 5))');
+        });
+
+        it('inverts an $or range group matching zero, flipping the HAVING conjunction (De Morgan)', function () {
+            runQuery({$or: [{'tag_count.count': {$lt: 1}}, {'tag_count.count': {$gt: 1}}]})
+                .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 1 and count(`posts_tags`.`tag_id`) <= 1))');
+        });
+
+        it('keeps mixed-direction statements in separate subqueries, each independently inverted', function () {
+            runQuery({$or: [{'tag_count.count': 0}, {'tag_count.count': {$gt: 5}}]})
+                .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0) or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 5))');
+        });
+    });
+
+    describe('combining with other filters', function () {
+        it('with a plain column in an $or group', function () {
+            runQuery({$or: [{status: 'draft'}, {'tag_count.count': {$gt: 1}}]})
+                .should.eql('select * from `posts` where (`posts`.`status` = \'draft\' or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
+        });
+
+        it('with a many-to-many relation in an $and group', function () {
+            runQuery({$and: [{'tags.slug': 'animal'}, {'tag_count.count': {$gt: 1}}]})
+                .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = \'animal\') and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
+        });
+
+        it('with a one-to-one relation in an $and group', function () {
+            runQuery({$and: [{'posts_meta.like_count': 42}, {'tag_count.count': {$gt: 1}}]})
+                .should.eql('select * from `posts` where (`posts`.`id` in (select `posts`.`id` from `posts` left join `posts_meta` on `posts_meta`.`post_id` = `posts`.`id` where `posts_meta`.`like_count` = 42) and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
+        });
+    });
+
+    describe('config-driven joins and wheres', function () {
+        it('applies the configured join chain and fixed wheres inside the subquery', function () {
+            runQuery({'public_tag_count.count': {$gt: 1}})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`visibility` = \'public\' group by `posts_tags`.`post_id` having count(distinct `posts_tags`.`tag_id`) > 1)');
+        });
+
+        it('keeps the configured join chain and fixed wheres when inverted', function () {
+            runQuery({'public_tag_count.count': 0})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`visibility` = \'public\' group by `posts_tags`.`post_id` having count(distinct `posts_tags`.`tag_id`) != 0)');
+        });
+    });
+
+    describe('guards', function () {
+        it('ignores operators that make no sense for aggregates', function () {
+            runQuery({'tag_count.count': {$regex: /x/}})
+                .should.eql('select * from `posts`');
+        });
+
+        it('throws on an unknown aggregate function', function () {
+            (function () {
+                convertor(knex('posts'), {'bad_count.count': 1}, {
+                    relations: {
+                        bad_count: {
+                            type: 'aggregate',
+                            aggregate: {fn: 'explode', column: 'posts_tags.tag_id'},
+                            tableName: 'posts_tags',
+                            joinFrom: 'post_id'
+                        }
+                    }
+                }).toQuery();
+            }).should.throw('Unknown aggregate function: explode');
+        });
     });
 });
 

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -487,37 +487,37 @@ describe('Aggregate Relations', function () {
     describe('operators matching a zero aggregate are inverted to NOT IN + complement HAVING', function () {
         it('$eq 0', function () {
             runQuery({'tag_count.count': 0})
-                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0)');
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0)');
         });
 
         it('$ne with a non-zero value', function () {
             runQuery({'tag_count.count': {$ne: 1}})
-                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) = 1)');
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) = 1)');
         });
 
         it('$lt', function () {
             runQuery({'tag_count.count': {$lt: 2}})
-                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 2)');
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 2)');
         });
 
         it('$lte 0', function () {
             runQuery({'tag_count.count': {$lte: 0}})
-                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 0)');
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 0)');
         });
 
         it('$gte 0 (matches everything)', function () {
             runQuery({'tag_count.count': {$gte: 0}})
-                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) < 0)');
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) < 0)');
         });
 
         it('$in containing zero', function () {
             runQuery({'tag_count.count': {$in: [0, 2]}})
-                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) not in (0, 2))');
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) not in (0, 2))');
         });
 
         it('$nin without zero', function () {
             runQuery({'tag_count.count': {$nin: [1]}})
-                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) in (1))');
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) in (1))');
         });
     });
 
@@ -529,12 +529,12 @@ describe('Aggregate Relations', function () {
 
         it('inverts an $or range group matching zero, flipping the HAVING conjunction (De Morgan)', function () {
             runQuery({$or: [{'tag_count.count': {$lt: 1}}, {'tag_count.count': {$gt: 1}}]})
-                .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 1 and count(`posts_tags`.`tag_id`) <= 1))');
+                .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 1 and count(`posts_tags`.`tag_id`) <= 1))');
         });
 
         it('keeps mixed-direction statements in separate subqueries, each independently inverted', function () {
             runQuery({$or: [{'tag_count.count': 0}, {'tag_count.count': {$gt: 5}}]})
-                .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0) or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 5))');
+                .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0) or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 5))');
         });
     });
 
@@ -553,6 +553,11 @@ describe('Aggregate Relations', function () {
             runQuery({$and: [{'posts_meta.like_count': 42}, {'tag_count.count': {$gt: 1}}]})
                 .should.eql('select * from `posts` where (`posts`.`id` in (select `posts`.`id` from `posts` left join `posts_meta` on `posts_meta`.`post_id` = `posts`.`id` where `posts_meta`.`like_count` = 42) and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
         });
+
+        it('with a join table filter in an $and group, restricting the aggregated rows', function () {
+            runQuery({$and: [{'posts_tags.sort_order': 0}, {'tag_count.count': {$gt: 1}}]})
+                .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`sort_order` = 0 group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
+        });
     });
 
     describe('config-driven joins and wheres', function () {
@@ -563,7 +568,7 @@ describe('Aggregate Relations', function () {
 
         it('keeps the configured join chain and fixed wheres when inverted', function () {
             runQuery({'public_tag_count.count': 0})
-                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`visibility` = \'public\' group by `posts_tags`.`post_id` having count(distinct `posts_tags`.`tag_id`) != 0)');
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `posts_tags`.`post_id` is not null and `tags`.`visibility` = \'public\' group by `posts_tags`.`post_id` having count(distinct `posts_tags`.`tag_id`) != 0)');
         });
     });
 
@@ -571,6 +576,50 @@ describe('Aggregate Relations', function () {
         it('ignores operators that make no sense for aggregates', function () {
             runQuery({'tag_count.count': {$regex: /x/}})
                 .should.eql('select * from `posts`');
+        });
+
+        it('ignores null values', function () {
+            runQuery({'tag_count.count': null})
+                .should.eql('select * from `posts`');
+        });
+
+        it('ignores non-numeric values whose database coercion would disagree with the inversion decision', function () {
+            runQuery({'tag_count.count': {$lt: '2abc'}})
+                .should.eql('select * from `posts`');
+        });
+
+        it('ignores arrays containing non-numeric values', function () {
+            runQuery({'tag_count.count': {$in: [null, 2]}})
+                .should.eql('select * from `posts`');
+        });
+
+        it('accepts numeric strings', function () {
+            runQuery({'tag_count.count': {$gt: '1'}})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > \'1\')');
+        });
+
+        it('empty $in matches nothing instead of generating invalid SQL', function () {
+            runQuery({'tag_count.count': {$in: []}})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having 1 = 0)');
+        });
+
+        it('empty $nin matches everything instead of generating invalid SQL', function () {
+            runQuery({'tag_count.count': {$nin: []}})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having 1 = 0)');
+        });
+
+        it('throws on a missing aggregate config', function () {
+            (function () {
+                convertor(knex('posts'), {'bad_count.count': 1}, {
+                    relations: {
+                        bad_count: {
+                            type: 'aggregate',
+                            tableName: 'posts_tags',
+                            joinFrom: 'post_id'
+                        }
+                    }
+                }).toQuery();
+            }).should.throw('Aggregate relations require an aggregate config with fn and column');
         });
 
         it('throws on an unknown aggregate function', function () {

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -24,6 +24,13 @@ const config = {
             type: 'oneToOne',
             joinFrom: 'post_id'
         },
+        authors: {
+            tableName: 'authors',
+            type: 'manyToMany',
+            joinTable: 'posts_authors',
+            joinFrom: 'post_id',
+            joinTo: 'author_id'
+        },
         tag_count: {
             type: 'aggregate',
             aggregate: {fn: 'count', column: 'posts_tags.tag_id'},
@@ -587,6 +594,14 @@ describe('Aggregate Relations', function () {
         it('with a join table filter in an inverted $and group', function () {
             runQuery({$and: [{'posts_tags.sort_order': 0}, {tag_count: 0}]})
                 .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null and `posts_tags`.`sort_order` = 0 group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0))');
+        });
+
+        it('ignores join table filters belonging to another relation in the $and group', function () {
+            // posts_authors is the authors relation's join table - it is never joined
+            // inside the tag_count subquery, so absorbing the filter there would
+            // reference an unknown table; it only restricts the authors subquery
+            runQuery({$and: [{'authors.slug': 'joe'}, {'posts_authors.sort_order': 0}, {tag_count: {$gt: 1}}]})
+                .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `authors` on `authors`.`id` = `posts_authors`.`author_id` and `posts_authors`.`sort_order` = 0 where `authors`.`slug` = \'joe\') and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
         });
     });
 

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -615,6 +615,36 @@ describe('Aggregate Relations', function () {
             }).should.throw(expectedError);
         });
 
+        it('throws on unknown operators instead of silently dropping the filter', function () {
+            (function () {
+                runQuery({tag_count: {$foo: 1}});
+            }).should.throw(expectedError);
+        });
+
+        it('throws on unknown operators inside an $and group', function () {
+            (function () {
+                runQuery({$and: [{status: 'draft'}, {tag_count: {$foo: 1}}]});
+            }).should.throw(expectedError);
+        });
+
+        it('throws on unknown operators inside an $or group', function () {
+            (function () {
+                runQuery({$or: [{status: 'draft'}, {tag_count: {$foo: 1}}]});
+            }).should.throw(expectedError);
+        });
+
+        it('throws on array values for scalar operators instead of generating invalid SQL', function () {
+            (function () {
+                runQuery({tag_count: {$gt: [1, 2]}});
+            }).should.throw(expectedError);
+        });
+
+        it('throws on an empty array value for scalar operators instead of generating invalid SQL', function () {
+            (function () {
+                runQuery({tag_count: {$eq: []}});
+            }).should.throw(expectedError);
+        });
+
         it('throws on null values', function () {
             (function () {
                 runQuery({tag_count: null});

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -573,24 +573,36 @@ describe('Aggregate Relations', function () {
     });
 
     describe('guards', function () {
-        it('ignores operators that make no sense for aggregates', function () {
-            runQuery({'tag_count.count': {$regex: /x/}})
-                .should.eql('select * from `posts`');
+        const expectedError = 'Aggregate relation "tag_count" only supports $eq, $ne, $gt, $gte, $lt, $lte, $in, $nin comparisons with numeric values';
+
+        it('throws on operators that make no sense for aggregates', function () {
+            (function () {
+                runQuery({'tag_count.count': {$regex: /x/}});
+            }).should.throw(expectedError);
         });
 
-        it('ignores null values', function () {
-            runQuery({'tag_count.count': null})
-                .should.eql('select * from `posts`');
+        it('throws on null values', function () {
+            (function () {
+                runQuery({'tag_count.count': null});
+            }).should.throw(expectedError);
         });
 
-        it('ignores non-numeric values whose database coercion would disagree with the inversion decision', function () {
-            runQuery({'tag_count.count': {$lt: '2abc'}})
-                .should.eql('select * from `posts`');
+        it('throws on non-numeric values whose database coercion would disagree with the inversion decision', function () {
+            (function () {
+                runQuery({'tag_count.count': {$lt: '2abc'}});
+            }).should.throw(expectedError);
         });
 
-        it('ignores arrays containing non-numeric values', function () {
-            runQuery({'tag_count.count': {$in: [null, 2]}})
-                .should.eql('select * from `posts`');
+        it('throws on arrays containing non-numeric values', function () {
+            (function () {
+                runQuery({'tag_count.count': {$in: [null, 2]}});
+            }).should.throw(expectedError);
+        });
+
+        it('throws when a valid statement shares a group with an invalid one, instead of dropping both', function () {
+            (function () {
+                runQuery({$or: [{'tag_count.count': {$gt: 1}}, {'tag_count.count': {$regex: /x/}}]});
+            }).should.throw(expectedError);
         });
 
         it('accepts numeric strings', function () {

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -463,145 +463,145 @@ describe('Relations', function () {
 describe('Aggregate Relations', function () {
     describe('operators not matching a zero aggregate use IN + HAVING as stated', function () {
         it('$eq with a non-zero value', function () {
-            runQuery({'tag_count.count': 2})
+            runQuery({tag_count: 2})
                 .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) = 2)');
         });
 
         it('$ne 0', function () {
-            runQuery({'tag_count.count': {$ne: 0}})
+            runQuery({tag_count: {$ne: 0}})
                 .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0)');
         });
 
         it('$gt', function () {
-            runQuery({'tag_count.count': {$gt: 1}})
+            runQuery({tag_count: {$gt: 1}})
                 .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1)');
         });
 
         it('$gte with a non-zero value', function () {
-            runQuery({'tag_count.count': {$gte: 1}})
+            runQuery({tag_count: {$gte: 1}})
                 .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 1)');
         });
 
         it('$in without zero', function () {
-            runQuery({'tag_count.count': {$in: [1, 2]}})
+            runQuery({tag_count: {$in: [1, 2]}})
                 .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) in (1, 2))');
         });
 
         it('$nin containing zero', function () {
-            runQuery({'tag_count.count': {$nin: [0]}})
+            runQuery({tag_count: {$nin: [0]}})
                 .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) not in (0))');
         });
     });
 
     describe('operators matching a zero aggregate are inverted to NOT IN + complement HAVING', function () {
         it('$eq 0', function () {
-            runQuery({'tag_count.count': 0})
+            runQuery({tag_count: 0})
                 .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0)');
         });
 
         it('$ne with a non-zero value', function () {
-            runQuery({'tag_count.count': {$ne: 1}})
+            runQuery({tag_count: {$ne: 1}})
                 .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) = 1)');
         });
 
         it('$lt', function () {
-            runQuery({'tag_count.count': {$lt: 2}})
+            runQuery({tag_count: {$lt: 2}})
                 .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 2)');
         });
 
         it('$lte 0', function () {
-            runQuery({'tag_count.count': {$lte: 0}})
+            runQuery({tag_count: {$lte: 0}})
                 .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 0)');
         });
 
         it('$gte 0 (matches everything)', function () {
-            runQuery({'tag_count.count': {$gte: 0}})
+            runQuery({tag_count: {$gte: 0}})
                 .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) < 0)');
         });
 
         it('$in containing zero', function () {
-            runQuery({'tag_count.count': {$in: [0, 2]}})
+            runQuery({tag_count: {$in: [0, 2]}})
                 .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) not in (0, 2))');
         });
 
         it('$nin without zero', function () {
-            runQuery({'tag_count.count': {$nin: [1]}})
+            runQuery({tag_count: {$nin: [1]}})
                 .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) in (1))');
         });
     });
 
     describe('grouping', function () {
         it('combines $and range conditions on the same aggregate into a single subquery', function () {
-            runQuery({$and: [{'tag_count.count': {$gt: 1}}, {'tag_count.count': {$lt: 5}}]})
+            runQuery({$and: [{tag_count: {$gt: 1}}, {tag_count: {$lt: 5}}]})
                 .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1 and count(`posts_tags`.`tag_id`) < 5))');
         });
 
         it('inverts an $or range group matching zero, flipping the HAVING conjunction (De Morgan)', function () {
-            runQuery({$or: [{'tag_count.count': {$lt: 1}}, {'tag_count.count': {$gt: 1}}]})
+            runQuery({$or: [{tag_count: {$lt: 1}}, {tag_count: {$gt: 1}}]})
                 .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 1 and count(`posts_tags`.`tag_id`) <= 1))');
         });
 
         it('combines mixed-direction $or statements into a single inverted subquery', function () {
-            runQuery({$or: [{'tag_count.count': 0}, {'tag_count.count': {$gt: 5}}]})
+            runQuery({$or: [{tag_count: 0}, {tag_count: {$gt: 5}}]})
                 .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0 and count(`posts_tags`.`tag_id`) <= 5))');
         });
 
         it('combines negated and regular conditions on the same aggregate into a single subquery', function () {
-            runQuery({$and: [{'tag_count.count': {$ne: 1}}, {'tag_count.count': {$gt: 0}}]})
+            runQuery({$and: [{tag_count: {$ne: 1}}, {tag_count: {$gt: 0}}]})
                 .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 1 and count(`posts_tags`.`tag_id`) > 0))');
         });
 
         it('combines multiple negated conditions into a single inverted subquery', function () {
-            runQuery({$and: [{'tag_count.count': {$ne: 1}}, {'tag_count.count': {$ne: 3}}]})
+            runQuery({$and: [{tag_count: {$ne: 1}}, {tag_count: {$ne: 3}}]})
                 .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) = 1 or count(`posts_tags`.`tag_id`) = 3))');
         });
     });
 
     describe('combining with other filters', function () {
         it('with a plain column in an $or group', function () {
-            runQuery({$or: [{status: 'draft'}, {'tag_count.count': {$gt: 1}}]})
+            runQuery({$or: [{status: 'draft'}, {tag_count: {$gt: 1}}]})
                 .should.eql('select * from `posts` where (`posts`.`status` = \'draft\' or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
         });
 
         it('with a many-to-many relation in an $and group', function () {
-            runQuery({$and: [{'tags.slug': 'animal'}, {'tag_count.count': {$gt: 1}}]})
+            runQuery({$and: [{'tags.slug': 'animal'}, {tag_count: {$gt: 1}}]})
                 .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = \'animal\') and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
         });
 
         it('with a one-to-one relation in an $and group', function () {
-            runQuery({$and: [{'posts_meta.like_count': 42}, {'tag_count.count': {$gt: 1}}]})
+            runQuery({$and: [{'posts_meta.like_count': 42}, {tag_count: {$gt: 1}}]})
                 .should.eql('select * from `posts` where (`posts`.`id` in (select `posts`.`id` from `posts` left join `posts_meta` on `posts_meta`.`post_id` = `posts`.`id` where `posts_meta`.`like_count` = 42) and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
         });
 
         it('with a join table filter in an $and group, restricting the aggregated rows', function () {
-            runQuery({$and: [{'posts_tags.sort_order': 0}, {'tag_count.count': {$gt: 1}}]})
+            runQuery({$and: [{'posts_tags.sort_order': 0}, {tag_count: {$gt: 1}}]})
                 .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`sort_order` = 0 group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
         });
 
         it('with a join table filter in an inverted $and group', function () {
-            runQuery({$and: [{'posts_tags.sort_order': 0}, {'tag_count.count': 0}]})
+            runQuery({$and: [{'posts_tags.sort_order': 0}, {tag_count: 0}]})
                 .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null and `posts_tags`.`sort_order` = 0 group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0))');
         });
     });
 
     describe('config-driven joins and wheres', function () {
         it('applies the configured join chain and fixed wheres inside the subquery', function () {
-            runQuery({'public_tag_count.count': {$gt: 1}})
+            runQuery({public_tag_count: {$gt: 1}})
                 .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`visibility` = \'public\' group by `posts_tags`.`post_id` having count(distinct `posts_tags`.`tag_id`) > 1)');
         });
 
         it('keeps the configured join chain and fixed wheres when inverted', function () {
-            runQuery({'public_tag_count.count': 0})
+            runQuery({public_tag_count: 0})
                 .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `posts_tags`.`post_id` is not null and `tags`.`visibility` = \'public\' group by `posts_tags`.`post_id` having count(distinct `posts_tags`.`tag_id`) != 0)');
         });
 
         it('aliases the aggregated table and joined tables via tableNameAs', function () {
-            runQuery({'aliased_public_tag_count.count': {$gt: 1}})
+            runQuery({aliased_public_tag_count: {$gt: 1}})
                 .should.eql('select * from `posts` where `posts`.`id` in (select `pt`.`post_id` from `posts_tags` as `pt` inner join `tags` as `t` on `t`.`id` = `pt`.`tag_id` where `t`.`visibility` = \'public\' group by `pt`.`post_id` having count(distinct `pt`.`tag_id`) > 1)');
         });
 
         it('keeps aliases when inverted', function () {
-            runQuery({'aliased_public_tag_count.count': 0})
+            runQuery({aliased_public_tag_count: 0})
                 .should.eql('select * from `posts` where `posts`.`id` not in (select `pt`.`post_id` from `posts_tags` as `pt` inner join `tags` as `t` on `t`.`id` = `pt`.`tag_id` where `pt`.`post_id` is not null and `t`.`visibility` = \'public\' group by `pt`.`post_id` having count(distinct `pt`.`tag_id`) != 0)');
         });
     });
@@ -611,52 +611,58 @@ describe('Aggregate Relations', function () {
 
         it('throws on operators that make no sense for aggregates', function () {
             (function () {
-                runQuery({'tag_count.count': {$regex: /x/}});
+                runQuery({tag_count: {$regex: /x/}});
             }).should.throw(expectedError);
         });
 
         it('throws on null values', function () {
             (function () {
-                runQuery({'tag_count.count': null});
+                runQuery({tag_count: null});
             }).should.throw(expectedError);
         });
 
         it('throws on non-numeric values whose database coercion would disagree with the inversion decision', function () {
             (function () {
-                runQuery({'tag_count.count': {$lt: '2abc'}});
+                runQuery({tag_count: {$lt: '2abc'}});
             }).should.throw(expectedError);
         });
 
         it('throws on arrays containing non-numeric values', function () {
             (function () {
-                runQuery({'tag_count.count': {$in: [null, 2]}});
+                runQuery({tag_count: {$in: [null, 2]}});
             }).should.throw(expectedError);
         });
 
         it('throws when a valid statement shares a group with an invalid one, instead of dropping both', function () {
             (function () {
-                runQuery({$or: [{'tag_count.count': {$gt: 1}}, {'tag_count.count': {$regex: /x/}}]});
+                runQuery({$or: [{tag_count: {$gt: 1}}, {tag_count: {$regex: /x/}}]});
             }).should.throw(expectedError);
         });
 
         it('accepts numeric strings', function () {
-            runQuery({'tag_count.count': {$gt: '1'}})
+            runQuery({tag_count: {$gt: '1'}})
                 .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > \'1\')');
         });
 
         it('empty $in matches nothing instead of generating invalid SQL', function () {
-            runQuery({'tag_count.count': {$in: []}})
+            runQuery({tag_count: {$in: []}})
                 .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having 1 = 0)');
         });
 
         it('empty $nin matches everything instead of generating invalid SQL', function () {
-            runQuery({'tag_count.count': {$nin: []}})
+            runQuery({tag_count: {$nin: []}})
                 .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having 1 = 0)');
+        });
+
+        it('throws on a dotted column suffix, every suffix would alias the same query', function () {
+            (function () {
+                runQuery({'tag_count.count': {$gt: 1}});
+            }).should.throw('Aggregate relation "tag_count" is queried by name only, without a column (e.g. "tag_count:0")');
         });
 
         it('throws on a missing aggregate config', function () {
             (function () {
-                convertor(knex('posts'), {'bad_count.count': 1}, {
+                convertor(knex('posts'), {bad_count: 1}, {
                     relations: {
                         bad_count: {
                             type: 'aggregate',
@@ -670,7 +676,7 @@ describe('Aggregate Relations', function () {
 
         it('throws when aggregate.fn is missing', function () {
             (function () {
-                convertor(knex('posts'), {'bad_count.count': 1}, {
+                convertor(knex('posts'), {bad_count: 1}, {
                     relations: {
                         bad_count: {
                             type: 'aggregate',
@@ -685,7 +691,7 @@ describe('Aggregate Relations', function () {
 
         it('throws when aggregate.column is missing', function () {
             (function () {
-                convertor(knex('posts'), {'bad_count.count': 1}, {
+                convertor(knex('posts'), {bad_count: 1}, {
                     relations: {
                         bad_count: {
                             type: 'aggregate',
@@ -700,7 +706,7 @@ describe('Aggregate Relations', function () {
 
         it('throws on an unknown aggregate function', function () {
             (function () {
-                convertor(knex('posts'), {'bad_count.count': 1}, {
+                convertor(knex('posts'), {bad_count: 1}, {
                     relations: {
                         bad_count: {
                             type: 'aggregate',

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -2,7 +2,7 @@ require('../utils');
 const knex = require('knex')({client: 'mysql2'});
 const convertor = require('../../lib/convertor');
 
-const runQuery = query => convertor(knex('posts'), query, {
+const config = {
     relations: {
         tags: {
             tableName: 'tags',
@@ -48,7 +48,13 @@ const runQuery = query => convertor(knex('posts'), query, {
             wheres: {'t.visibility': 'public'}
         }
     }
-}).toQuery();
+};
+
+// Builds the full SQL string - rendering also runs the deferred knex where-callbacks
+const runQuery = query => convertor(knex('posts'), query, config).toQuery();
+
+// Builds the query object without rendering it, like consumers do before executing
+const buildQuery = query => convertor(knex('posts'), query, config);
 
 describe('Simple Expressions', function () {
     it('should match based on simple id', function () {
@@ -688,6 +694,36 @@ describe('Aggregate Relations', function () {
             (function () {
                 runQuery({'tag_count.count': {$gt: 1}});
             }).should.throw('Aggregate relation "tag_count" is queried by name only, without a column (e.g. "tag_count:0")');
+        });
+
+        describe('throws while building the query, not while rendering it', function () {
+            // Grouped statements are compiled inside knex where-callbacks, which only
+            // run once the query is rendered - validation must not wait for that, or
+            // the error escapes the error handling wrapped around the query build
+            // (e.g. the layer turning invalid filters into 4xx responses)
+            it('for an invalid value inside an $and group', function () {
+                (function () {
+                    buildQuery({$and: [{status: 'draft'}, {tag_count: null}]});
+                }).should.throw(expectedError);
+            });
+
+            it('for an unknown operator inside an $or group', function () {
+                (function () {
+                    buildQuery({$or: [{status: 'draft'}, {tag_count: {$foo: 1}}]});
+                }).should.throw(expectedError);
+            });
+
+            it('for an invalid value inside a nested group', function () {
+                (function () {
+                    buildQuery({$and: [{status: 'draft'}, {$or: [{featured: true}, {tag_count: 'abc'}]}]});
+                }).should.throw(expectedError);
+            });
+
+            it('for a dotted column suffix inside an $and group', function () {
+                (function () {
+                    buildQuery({$and: [{status: 'draft'}, {'tag_count.count': {$gt: 1}}]});
+                }).should.throw('Aggregate relation "tag_count" is queried by name only, without a column (e.g. "tag_count:0")');
+            });
         });
 
         it('throws on a missing aggregate config', function () {

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -532,9 +532,19 @@ describe('Aggregate Relations', function () {
                 .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 1 and count(`posts_tags`.`tag_id`) <= 1))');
         });
 
-        it('keeps mixed-direction statements in separate subqueries, each independently inverted', function () {
+        it('combines mixed-direction $or statements into a single inverted subquery', function () {
             runQuery({$or: [{'tag_count.count': 0}, {'tag_count.count': {$gt: 5}}]})
-                .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0) or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 5))');
+                .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0 and count(`posts_tags`.`tag_id`) <= 5))');
+        });
+
+        it('combines negated and regular conditions on the same aggregate into a single subquery', function () {
+            runQuery({$and: [{'tag_count.count': {$ne: 1}}, {'tag_count.count': {$gt: 0}}]})
+                .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 1 and count(`posts_tags`.`tag_id`) > 0))');
+        });
+
+        it('combines multiple negated conditions into a single inverted subquery', function () {
+            runQuery({$and: [{'tag_count.count': {$ne: 1}}, {'tag_count.count': {$ne: 3}}]})
+                .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) = 1 or count(`posts_tags`.`tag_id`) = 3))');
         });
     });
 

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -675,9 +675,19 @@ describe('Aggregate Relations', function () {
             }).should.throw(expectedError);
         });
 
-        it('accepts numeric strings', function () {
+        it('binds numeric strings as numbers, the database must compare what the inversion decision compared', function () {
             runQuery({tag_count: {$gt: '1'}})
-                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > \'1\')');
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1)');
+        });
+
+        it('binds numeric strings as numbers when inverted', function () {
+            runQuery({tag_count: {$lt: '2'}})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 2)');
+        });
+
+        it('binds numeric strings in set operators as numbers', function () {
+            runQuery({tag_count: {$in: ['1', 2]}})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) in (1, 2))');
         });
 
         it('empty $in matches nothing instead of generating invalid SQL', function () {

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -558,6 +558,11 @@ describe('Aggregate Relations', function () {
             runQuery({$and: [{'posts_tags.sort_order': 0}, {'tag_count.count': {$gt: 1}}]})
                 .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`sort_order` = 0 group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
         });
+
+        it('with a join table filter in an inverted $and group', function () {
+            runQuery({$and: [{'posts_tags.sort_order': 0}, {'tag_count.count': 0}]})
+                .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null and `posts_tags`.`sort_order` = 0 group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0))');
+        });
     });
 
     describe('config-driven joins and wheres', function () {
@@ -626,6 +631,36 @@ describe('Aggregate Relations', function () {
                     relations: {
                         bad_count: {
                             type: 'aggregate',
+                            tableName: 'posts_tags',
+                            joinFrom: 'post_id'
+                        }
+                    }
+                }).toQuery();
+            }).should.throw('Aggregate relations require an aggregate config with fn and column');
+        });
+
+        it('throws when aggregate.fn is missing', function () {
+            (function () {
+                convertor(knex('posts'), {'bad_count.count': 1}, {
+                    relations: {
+                        bad_count: {
+                            type: 'aggregate',
+                            aggregate: {column: 'posts_tags.tag_id'},
+                            tableName: 'posts_tags',
+                            joinFrom: 'post_id'
+                        }
+                    }
+                }).toQuery();
+            }).should.throw('Aggregate relations require an aggregate config with fn and column');
+        });
+
+        it('throws when aggregate.column is missing', function () {
+            (function () {
+                convertor(knex('posts'), {'bad_count.count': 1}, {
+                    relations: {
+                        bad_count: {
+                            type: 'aggregate',
+                            aggregate: {fn: 'count'},
                             tableName: 'posts_tags',
                             joinFrom: 'post_id'
                         }

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -37,6 +37,15 @@ const runQuery = query => convertor(knex('posts'), query, {
             joinFrom: 'post_id',
             joins: [{tableName: 'tags', from: 'id', to: 'tag_id'}],
             wheres: {'tags.visibility': 'public'}
+        },
+        aliased_public_tag_count: {
+            type: 'aggregate',
+            aggregate: {fn: 'countDistinct', column: 'pt.tag_id'},
+            tableName: 'posts_tags',
+            tableNameAs: 'pt',
+            joinFrom: 'post_id',
+            joins: [{tableName: 'tags', tableNameAs: 't', from: 'id', to: 'tag_id'}],
+            wheres: {'t.visibility': 'public'}
         }
     }
 }).toQuery();
@@ -584,6 +593,16 @@ describe('Aggregate Relations', function () {
         it('keeps the configured join chain and fixed wheres when inverted', function () {
             runQuery({'public_tag_count.count': 0})
                 .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `posts_tags`.`post_id` is not null and `tags`.`visibility` = \'public\' group by `posts_tags`.`post_id` having count(distinct `posts_tags`.`tag_id`) != 0)');
+        });
+
+        it('aliases the aggregated table and joined tables via tableNameAs', function () {
+            runQuery({'aliased_public_tag_count.count': {$gt: 1}})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `pt`.`post_id` from `posts_tags` as `pt` inner join `tags` as `t` on `t`.`id` = `pt`.`tag_id` where `t`.`visibility` = \'public\' group by `pt`.`post_id` having count(distinct `pt`.`tag_id`) > 1)');
+        });
+
+        it('keeps aliases when inverted', function () {
+            runQuery({'aliased_public_tag_count.count': 0})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `pt`.`post_id` from `posts_tags` as `pt` inner join `tags` as `t` on `t`.`id` = `pt`.`tag_id` where `pt`.`post_id` is not null and `t`.`visibility` = \'public\' group by `pt`.`post_id` having count(distinct `pt`.`tag_id`) != 0)');
         });
     });
 


### PR DESCRIPTION
## What

Adds a config-driven `aggregate` relation type to mongo-knex so NQL filters can express "count of related rows" predicates, e.g. `active_stripe_customers_count:>1`, generating a grouped subquery:

```sql
WHERE members.id IN (
    SELECT msc.member_id FROM members_stripe_customers msc
    JOIN members_stripe_customers_subscriptions s ON s.customer_id = msc.customer_id
    WHERE s.status = 'active' AND s.cancel_at_period_end = FALSE
    GROUP BY msc.member_id
    HAVING COUNT(DISTINCT msc.customer_id) > 1
)
```

The relation config defines everything — no new NQL syntax is needed:

```js
active_stripe_customers_count: {
    type: 'aggregate',
    aggregate: {fn: 'countDistinct', column: 'members_stripe_customers.customer_id'},
    tableName: 'members_stripe_customers',
    joinFrom: 'member_id',
    joins: [{tableName: 'members_stripe_customers_subscriptions', from: 'customer_id', to: 'customer_id'}],
    wheres: {'members_stripe_customers_subscriptions.status': 'active', 'members_stripe_customers_subscriptions.cancel_at_period_end': false}
}
```

Aggregate relations are queried by **bare relation name only** (`active_stripe_customers_count:>1`, `tag_count:0`). Unlike the other relation types there is no column to select — the config defines what is computed — so a dotted suffix would be purely decorative: `tag_count.count`, `tag_count.total` and `tag_count.banana` would all compile to the identical query. To avoid blessing arbitrary aliased spellings, a dotted key naming an aggregate relation throws. This keeps a single canonical spelling and leaves the dotted form free to mean something in future (e.g. selecting different functions over the same relation). Legacy spellings such as `active_stripe_customers.count` can be mapped to the bare name with a filter expansion at the NQL layer.

Supported aggregate functions: `count`, `countDistinct`, `sum` — the three where "no related rows" is soundly equivalent to an aggregate value of 0. `min`/`max`/`avg` are NULL over no rows, which would break the zero-count inversion below, so they are deliberately excluded until a use case arrives with thought-through NULL semantics. Supported operators: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`.

## Why

Ghost's `count.active_stripe_customers:>1` members filter is currently special-cased outside NQL entirely (an input serializer allowlists the exact filter string and a custom Bookshelf query builds the join by hand), so it can't be combined with any other NQL predicate. With this, aggregates become a first-class relation type: Ghost can register the filter via its normal `filterRelations()` config, delete the special-casing, and the predicate composes with AND/OR and everything else NQL supports. Any existing dotted spellings in the wild map to the bare relation name via `filterExpansions` (the same mechanism as `tags` → `tags.slug`), so backwards compatibility is an enumerated allowlist rather than accepting arbitrary suffixes.

## Zero-count correctness

A parent row with no qualifying related rows never appears in the grouped subquery at all, so any predicate that matches an aggregate value of 0 must be inverted rather than expressed as a plain `IN ... HAVING`:

| filter | generated |
| --- | --- |
| `count:>1` | `id IN (... HAVING count > 1)` |
| `count:<2` | `id NOT IN (... HAVING count >= 2)` |
| `count:0` | `id NOT IN (... HAVING count != 0)` |
| `count:-1` | `id NOT IN (... HAVING count = 1)` |

The rule is general: if the group's combined predicate matches 0 (`every` statement in `$and` context, `some` in `$or`), the subquery becomes `NOT IN` with each operator replaced by its complement and the HAVING conjunction flipped (De Morgan). This is the detail the naive LEFT-JOIN approach gets wrong and the reason aggregates need first-class support.

Existing grouping machinery composes as expected: `count:>1+count:<5` lands in a single subquery with combined HAVING clauses, `$ne` splits into its own subquery, and `$or` context flows through to the outer where.

## Tests

- Unit: SQL-string coverage of the full operator inversion table (both directions for every operator), De Morgan flip on inverted `$or` groups, single-subquery range combining, config-driven joins+wheres, combination with plain columns and manyToMany/oneToOne relations, guards (dotted column suffixes throw, unsupported operators/non-numeric values throw, malformed config throws, empty `$in`/`$nin` arrays degrade to `1 = 0`, inverted subqueries guard against orphaned NULL join rows).
- Integration (SQLite + MySQL 8.0): operator matrix × `$and`/`$or` × negation against real data, with zero-count rows as the centrepiece — including a `sum` case where "no related rows" and "rows summing to zero" both match `sum:0`, and a join+wheres relation proving only qualifying rows are counted. Replaces the previously skipped `COUNT` placeholder tests, which this supersedes.

Out of scope: Ghost-side adoption (relation config + `filterExpansions` entries for legacy dotted spellings + deleting the serializer allowlist) — separate Ghost PR once this is released.
