### PR TITLE
Fixed aggregate relation validation timing, numeric strings and join filters

### DIFF
--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -641,8 +641,13 @@ class MongoToKnex {
                 const useOr = idx !== 0 && ((mode === '$or') !== invertSubquery);
                 const havingType = useOr ? 'orHavingRaw' : 'havingRaw';
 
+                // CASE: values are validated numeric but can arrive as numeric strings
+                //       (e.g. quoted filter values) - they are bound as numbers so the
+                //       database comparison matches the inversion decision above, which
+                //       evaluates the predicate via Number() (e.g. SQLite would never
+                //       coerce, an integer aggregate always sorts below any string)
                 if (isStatementGroupOp(compOps[operator])) {
-                    const statementValue = _.castArray(statement.value);
+                    const statementValue = _.castArray(statement.value).map(Number);
 
                     // CASE: IN () is invalid SQL and an empty set can never match
                     if (statementValue.length === 0) {
@@ -653,7 +658,7 @@ class MongoToKnex {
                     const placeholders = statementValue.map(() => '?').join(', ');
                     innerQB[havingType](`${aggregateFunction} ${compOps[operator]} (${placeholders})`, [config.aggregate.column, ...statementValue]);
                 } else {
-                    innerQB[havingType](`${aggregateFunction} ${compOps[operator]} ?`, [config.aggregate.column, statement.value]);
+                    innerQB[havingType](`${aggregateFunction} ${compOps[operator]} ?`, [config.aggregate.column, Number(statement.value)]);
                 }
             });
 

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -594,6 +594,14 @@ class MongoToKnex {
         const baseTable = config.tableNameAs || config.tableName;
         const baseTableValue = config.tableNameAs ? `${config.tableName} as ${config.tableNameAs}` : config.tableName;
 
+        // CASE: $and groups attach every join table filter of the group to every
+        //       relation subquery - only filters on tables that are part of this
+        //       subquery's join chain can restrict the aggregated rows, the others
+        //       reference tables that are never joined here and are handled by their
+        //       own relation's subquery
+        const subqueryTables = [baseTable, ..._.map(config.joins, join => join.tableNameAs || join.tableName)];
+        const applicableJoinFilters = _.filter(joinFilterStatements, joinFilter => subqueryTables.includes(joinFilter.joinTable));
+
         // CASE: WHERE resource.id (IN | NOT IN) (SELECT ... GROUP BY ... HAVING ...)
         qb[whereType](`${this.tableName}.id`, comp, function () {
             const innerQB = this
@@ -626,7 +634,7 @@ class MongoToKnex {
 
             // CASE: when applying AND conjunction, filters on a join table restrict
             //       which related rows are aggregated (same as the other relation types)
-            _.each(joinFilterStatements, (joinFilter) => {
+            _.each(applicableJoinFilters, (joinFilter) => {
                 innerQB.where(`${joinFilter.joinTable}.${joinFilter.column}`, compOps[joinFilter.operator], joinFilter.value);
             });
 

--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -71,6 +71,9 @@ const isAggregateValue = (op, value) => {
 //eslint-disable-next-line ghost/ghost-custom/no-native-error
 const aggregateOperatorError = relationName => new Error(`Aggregate relation "${relationName}" only supports ${Object.keys(complementOps).join(', ')} comparisons with numeric values`);
 
+//eslint-disable-next-line ghost/ghost-custom/no-native-error
+const aggregateColumnError = relationName => new Error(`Aggregate relation "${relationName}" is queried by name only, without a column (e.g. "${relationName}:0")`);
+
 /**
  * Whether an aggregate comparison would match a parent row with no related rows
  * (aggregate value 0). Such rows don't appear in the grouped subquery at all, so
@@ -202,8 +205,7 @@ class MongoToKnex {
             //       column to select - a dotted suffix is meaningless and only invites
             //       aliased spellings of the same query, so it's rejected outright
             if (relation && relation.type === 'aggregate') {
-                //eslint-disable-next-line ghost/ghost-custom/no-native-error
-                throw new Error(`Aggregate relation "${table}" is queried by name only, without a column (e.g. "${table}:0")`);
+                throw aggregateColumnError(table);
             }
 
             if (!relation) {
@@ -541,15 +543,8 @@ class MongoToKnex {
                     debug(`one of ${key} group statements contains unknown operator`);
                 }
             } else if (reference.config.type === 'aggregate') {
-                // CASE: unlike the other relation types we throw instead of silently dropping
-                //       the group - a dropped statement widens the result set, returning rows
-                //       the filter was meant to exclude
-                const invalidStatement = statements.find(s => !isAggregateCompOp(s.operator) || !isAggregateValue(s.operator, s.value));
-
-                if (invalidStatement) {
-                    throw aggregateOperatorError(invalidStatement.table);
-                }
-
+                // NOTE: operators and values were already validated by the
+                //       validateAggregateStatements pre-pass in processJSON
                 this.buildAggregateRelationQuery(qb, statements, reference, mode, groupedRelations[key].joinFilterStatements);
             }
         });
@@ -747,21 +742,12 @@ class MongoToKnex {
         }
 
         // CASE: sub is an object, contains statements and operators
+        //       (unknown operators on aggregate relations were already rejected by
+        //       the validateAggregateStatements pre-pass in processJSON)
         _.forIn(sub, (value, op) => {
             if (isCompOp(op)) {
                 this.buildComparison(qb, mode, statement, op, value, group);
             } else {
-                // CASE: unknown operators are dropped, but for aggregate relations a
-                //       dropped statement widens the result set, so they fail closed -
-                //       this has to happen here because dropped statements never reach
-                //       the aggregate validation in buildRelationQuery
-                const [relationName] = statement.split('.');
-                const relation = this.config.relations[relationName];
-
-                if (relation && relation.type === 'aggregate') {
-                    throw aggregateOperatorError(relationName);
-                }
-
                 debug('unknown operator');
             }
         });
@@ -816,6 +802,57 @@ class MongoToKnex {
     }
 
     /**
+     * Validate every aggregate statement before any query is built. Unlike the other
+     * relation types invalid aggregate statements throw instead of being silently
+     * dropped - a dropped statement widens the result set, returning rows the filter
+     * was meant to exclude.
+     *
+     * Validation is a separate pre-pass because grouped statements ($and/$or) are
+     * built inside knex where-callbacks, which only run once the query is rendered -
+     * a throw from there surfaces after query building has finished, escaping any
+     * error handling wrapped around it (e.g. the layer turning invalid filters into
+     * 4xx responses).
+     */
+    validateAggregateStatements(sub) {
+        if (!_.isPlainObject(sub)) {
+            return;
+        }
+
+        _.forIn(sub, (value, key) => {
+            if (isLogicOp(key)) {
+                _.castArray(value).forEach(group => this.validateAggregateStatements(group));
+                return;
+            }
+
+            if (isOp(key)) {
+                return;
+            }
+
+            const [relationName, columnName] = key.split('.');
+            const relation = this.config.relations[relationName];
+
+            if (!relation || relation.type !== 'aggregate') {
+                return;
+            }
+
+            // CASE: same rejection as processStatement, raised here so it fires
+            //       before query building for grouped statements too
+            if (columnName) {
+                throw aggregateColumnError(relationName);
+            }
+
+            // CASE: an atomic value (incl. arrays and regexes) is shorthand for $eq
+            const statements = _.isPlainObject(value) ? value : {$eq: value};
+
+            _.forIn(statements, (statementValue, op) => {
+                if (!isAggregateCompOp(op) || !isAggregateValue(op, statementValue)) {
+                    throw aggregateOperatorError(relationName);
+                }
+            });
+        });
+    }
+
+    /**
      * The converter receives sub query objects e.g. `qb.where('..', (qb) => {})`, which
      * we then pass around to our class methods. That's why we pass the parent `qb` object
      * around instead of remembering it as `this.qb`. There are multiple `qb` objects.
@@ -827,6 +864,8 @@ class MongoToKnex {
         if (debugExtended.enabled) {
             debugExtended(`(processJSON) ${stringify(mongoJSON)}`);
         }
+
+        this.validateAggregateStatements(mongoJSON);
 
         // 'and' is the default behaviour
         this.buildQuery(qb, '$and', mongoJSON);

--- a/packages/mongo-knex/test/integration/relations.test.js
+++ b/packages/mongo-knex/test/integration/relations.test.js
@@ -2191,6 +2191,37 @@ describe('Relations', function () {
                         result.should.matchIds([4, 6, 8]);
                     });
             });
+
+            it('combined with a join table filter belonging to another relation', function () {
+                // posts_authors is the authors relation's join table - it must restrict
+                // the authors subquery only, the tag_count subquery never joins it
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'authors.slug': 'pat'
+                        },
+                        {
+                            'posts_authors.sort_order': 1
+                        },
+                        {
+                            tag_count: {
+                                $gt: 1
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        // pat is attached with sort_order 1 to post 4 only,
+                        // posts 4 and 6 have more than one tag
+                        result.should.be.an.Array().with.lengthOf(1);
+                        result.should.matchIds([4]);
+                    });
+            });
         });
 
         describe('OR $or', function () {

--- a/packages/mongo-knex/test/integration/relations.test.js
+++ b/packages/mongo-knex/test/integration/relations.test.js
@@ -1936,6 +1936,63 @@ describe('Relations', function () {
             });
         });
 
+        describe('numeric strings', function () {
+            // CASE: numeric strings must match the same rows as their numeric value -
+            //       bound as strings the comparison silently diverges from the JS-side
+            //       inversion decision (SQLite never coerces: an integer aggregate
+            //       always sorts below any string, so e.g. < '2' matched every post)
+            it('tag_count is < "2" matches the same rows as the numeric value (inverted)', function () {
+                const mongoJSON = {
+                    tag_count: {
+                        $lt: '2'
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(6);
+                        result.should.matchIds([1, 2, 3, 5, 7, 8]);
+                    });
+            });
+
+            it('tag_count is > "1" matches the same rows as the numeric value', function () {
+                const mongoJSON = {
+                    tag_count: {
+                        $gt: '1'
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result.should.matchIds([4, 6]);
+                    });
+            });
+
+            it('tag_count is in ["1", "2"] matches the same rows as the numeric values', function () {
+                const mongoJSON = {
+                    tag_count: {
+                        $in: ['1', '2']
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(7);
+                        result.should.matchIds([1, 2, 3, 4, 5, 6, 8]);
+                    });
+            });
+        });
+
         describe('AND $and', function () {
             it('range conditions on the same aggregate combine in one subquery', function () {
                 const mongoJSON = {

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -24,6 +24,13 @@ const config = {
             type: 'oneToOne',
             joinFrom: 'post_id'
         },
+        authors: {
+            tableName: 'authors',
+            type: 'manyToMany',
+            joinTable: 'posts_authors',
+            joinFrom: 'post_id',
+            joinTo: 'author_id'
+        },
         tag_count: {
             type: 'aggregate',
             aggregate: {fn: 'count', column: 'posts_tags.tag_id'},
@@ -587,6 +594,14 @@ describe('Aggregate Relations', function () {
         it('with a join table filter in an inverted $and group', function () {
             runQuery({$and: [{'posts_tags.sort_order': 0}, {tag_count: 0}]})
                 .should.eql('select * from `posts` where (`posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null and `posts_tags`.`sort_order` = 0 group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) != 0))');
+        });
+
+        it('ignores join table filters belonging to another relation in the $and group', function () {
+            // posts_authors is the authors relation's join table - it is never joined
+            // inside the tag_count subquery, so absorbing the filter there would
+            // reference an unknown table; it only restricts the authors subquery
+            runQuery({$and: [{'authors.slug': 'joe'}, {'posts_authors.sort_order': 0}, {tag_count: {$gt: 1}}]})
+                .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `authors` on `authors`.`id` = `posts_authors`.`author_id` and `posts_authors`.`sort_order` = 0 where `authors`.`slug` = \'joe\') and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1))');
         });
     });
 

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -2,7 +2,7 @@ require('../utils');
 const knex = require('knex')({client: 'mysql2'});
 const convertor = require('../../lib/convertor');
 
-const runQuery = query => convertor(knex('posts'), query, {
+const config = {
     relations: {
         tags: {
             tableName: 'tags',
@@ -48,7 +48,13 @@ const runQuery = query => convertor(knex('posts'), query, {
             wheres: {'t.visibility': 'public'}
         }
     }
-}).toQuery();
+};
+
+// Builds the full SQL string - rendering also runs the deferred knex where-callbacks
+const runQuery = query => convertor(knex('posts'), query, config).toQuery();
+
+// Builds the query object without rendering it, like consumers do before executing
+const buildQuery = query => convertor(knex('posts'), query, config);
 
 describe('Simple Expressions', function () {
     it('should match based on simple id', function () {
@@ -688,6 +694,36 @@ describe('Aggregate Relations', function () {
             (function () {
                 runQuery({'tag_count.count': {$gt: 1}});
             }).should.throw('Aggregate relation "tag_count" is queried by name only, without a column (e.g. "tag_count:0")');
+        });
+
+        describe('throws while building the query, not while rendering it', function () {
+            // Grouped statements are compiled inside knex where-callbacks, which only
+            // run once the query is rendered - validation must not wait for that, or
+            // the error escapes the error handling wrapped around the query build
+            // (e.g. the layer turning invalid filters into 4xx responses)
+            it('for an invalid value inside an $and group', function () {
+                (function () {
+                    buildQuery({$and: [{status: 'draft'}, {tag_count: null}]});
+                }).should.throw(expectedError);
+            });
+
+            it('for an unknown operator inside an $or group', function () {
+                (function () {
+                    buildQuery({$or: [{status: 'draft'}, {tag_count: {$foo: 1}}]});
+                }).should.throw(expectedError);
+            });
+
+            it('for an invalid value inside a nested group', function () {
+                (function () {
+                    buildQuery({$and: [{status: 'draft'}, {$or: [{featured: true}, {tag_count: 'abc'}]}]});
+                }).should.throw(expectedError);
+            });
+
+            it('for a dotted column suffix inside an $and group', function () {
+                (function () {
+                    buildQuery({$and: [{status: 'draft'}, {'tag_count.count': {$gt: 1}}]});
+                }).should.throw('Aggregate relation "tag_count" is queried by name only, without a column (e.g. "tag_count:0")');
+            });
         });
 
         it('throws on a missing aggregate config', function () {

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -675,9 +675,19 @@ describe('Aggregate Relations', function () {
             }).should.throw(expectedError);
         });
 
-        it('accepts numeric strings', function () {
+        it('binds numeric strings as numbers, the database must compare what the inversion decision compared', function () {
             runQuery({tag_count: {$gt: '1'}})
-                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > \'1\')');
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) > 1)');
+        });
+
+        it('binds numeric strings as numbers when inverted', function () {
+            runQuery({tag_count: {$lt: '2'}})
+                .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` where `posts_tags`.`post_id` is not null group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) >= 2)');
+        });
+
+        it('binds numeric strings in set operators as numbers', function () {
+            runQuery({tag_count: {$in: ['1', 2]}})
+                .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` group by `posts_tags`.`post_id` having count(`posts_tags`.`tag_id`) in (1, 2))');
         });
 
         it('empty $in matches nothing instead of generating invalid SQL', function () {


### PR DESCRIPTION
## What

Three independent correctness fixes for the `aggregate` relation type introduced in #152, one commit per fix. Stacked on `aggregate-relation-type` so it can be reviewed standalone and merged into that branch before #152 lands.

### 1. Moved aggregate filter validation ahead of deferred query building

Grouped statements (`$and`/`$or`) are compiled inside knex where-callbacks, which only run once the query is rendered — so the fail-closed validation guards fired *after* query building had returned, escaping any error handling wrapped around the build. In Ghost, `bookshelf-filter` only wraps the synchronous `querySQL()` call: an invalid combined filter (`status:free+count.active_stripe_customers:null`) became a **500 at fetch time**, while the same invalid filter standalone was a 400.

Validation now runs as a pre-pass over the mongo JSON at `convertor()` time, so every invalid aggregate statement (bad operator, non-numeric value, dotted suffix) throws during the build wherever it sits in the group tree. This also consolidates the two previous validation seams (the per-group scan in `buildRelationQuery` and the unknown-operator special case in `buildWhereClause`) into one.

### 2. Fixed numeric string aggregate values being compared as text

The value guard accepts numeric strings (quoted filter values arrive as strings via nql-lang), but they were bound into the HAVING clause as-is while the subquery inversion decision evaluates the predicate via `Number()`. The two evaluations could disagree — on SQLite an integer aggregate always sorts below any bound string, so `tag_count:<'2'` inverted to NOT IN over an always-false HAVING and **matched every row**, while `tag_count:>'1'` matched none (reproduced in the new integration tests, which fail without the fix). MySQL diverged for hex/binary strings (`'0x10'` is 16 in JS, 0 in SQL). Values are now bound as numbers, including `$in`/`$nin` lists.

### 3. Scoped join table filters to the aggregate subquery's join chain

`$and` groups attach every join table filter in the group to every relation subquery. The aggregate branch absorbed all of them as plain WHEREs — including filters on join tables belonging to *other* relations, tables never joined inside the aggregate subquery. `authors.slug:joe+posts_authors.sort_order:0+tag_count:>1` generated SQL referencing an unjoined `posts_authors` and failed with an unknown-column error at execution time. Aggregate subqueries now only absorb join table filters whose table is part of their own join chain; foreign ones are left to the owning relation's subquery, same as combining two regular relations.

## Why

Review of #152 (and TryGhost/Ghost#28547) surfaced these three as merge blockers: #1 regresses the public error contract the Ghost PR aims to preserve (400 for invalid filters), #2 silently returns wrong member sets on SQLite-backed installs, #3 breaks the filter composition that is the whole point of the change.

Note: the cross-relation join filter leak (#3's mechanism) pre-exists for `manyToMany`/`oneToOne` in `groupRelationStatements`, and the engine still silently drops some non-aggregate statements (unsupported relation types, orphaned join table filters). Those are general, pre-existing issues tracked separately — this PR only keeps the new aggregate path from inheriting them.
