### PR TITLE
Switched npm publishing to OIDC trusted publishing via GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,96 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/*/package.json'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Preview what would be published without actually publishing'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    # Run for ship/version commits or manual dispatch.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'Published new versions')
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      FORCE_COLOR: 1
+      CI: true
+      NPM_CONFIG_PROVENANCE: true
+      NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --prefer-offline
+
+      - name: Build releasable packages
+        run: yarn build
+
+      - name: Configure npm registry
+        run: |
+          cat > "$HOME/.npmrc" <<EOF
+          registry=https://registry.npmjs.org/
+          @tryghost:registry=https://registry.npmjs.org/
+          EOF
+          npm config get registry
+          npm config get @tryghost:registry
+
+      - name: Determine packages to publish
+        id: pubs
+        run: |
+          to_publish=()
+          for pkg in packages/*/package.json; do
+            name=$(jq -r .name "$pkg")
+            version=$(jq -r .version "$pkg")
+            if [ -n "$(npm view "$name@$version" version 2>/dev/null)" ]; then
+              echo "skip $name@$version (already published)"
+            else
+              echo "queue $name@$version"
+              to_publish+=("$(dirname "$pkg")")
+            fi
+          done
+          if [ ${#to_publish[@]} -eq 0 ]; then
+            echo "nothing to publish"
+            echo "dirs=" >> "$GITHUB_OUTPUT"
+          else
+            (IFS=,; echo "dirs=${to_publish[*]}") >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.pubs.outputs.dirs != ''
+        run: |
+          IFS=',' read -ra dirs <<< "${{ steps.pubs.outputs.dirs }}"
+          for dir in "${dirs[@]}"; do
+            (cd "$dir" && npm publish ${{ (github.event.inputs['dry-run'] == 'true' && '--dry-run') || '' }})
+          done
+
+      - uses: tryghost/actions/actions/slack-build@128d496a57fb11e44e97d690f0d5381c58e52489 # main
+        if: failure()
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ To add a new package to the repo:
 
 ## Publish
 
-- `yarn ship` is an alias for `lerna publish`
-    - Publishes all packages which have changed
-    - Also updates any packages which depend on changed packages
+- `yarn ship` is an alias for `lerna version`
+    - Bumps the version of all packages which have changed, also updating any packages which depend on them
+    - Commits the new versions ("Published new versions"), tags the releases, and pushes to the remote (set `GHOST_UPSTREAM` to push to a remote other than `origin`)
+    - Publishing to npm happens in CI: the [Publish workflow](.github/workflows/publish.yml) picks up the version commit on `main` and publishes any package versions missing from the registry via [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers)
+    - If a publish fails, re-run the Publish workflow from the Actions tab (with dry-run disabled) — it only publishes versions not yet on the registry, so it is safe to retry
 
 
 # Copyright & License 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "npmClient": "yarn",
     "packages": ["packages/*"],
     "command": {
-        "publish": {
+        "version": {
             "allowBranch": "main",
             "message": "Published new versions"
         }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "pretest": "yarn build",
     "lint": "lerna run lint",
     "preship": "yarn test",
-    "ship": "lerna publish --git-remote ${GHOST_UPSTREAM:-origin}"
+    "ship": "lerna version --git-remote ${GHOST_UPSTREAM:-origin}"
   },
   "devDependencies": {
     "eslint": "8.39.0",

--- a/packages/mongo-knex/package.json
+++ b/packages/mongo-knex/package.json
@@ -2,7 +2,11 @@
   "name": "@tryghost/mongo-knex",
   "version": "0.10.0",
   "description": "tbc",
-  "repository": "https://github.com/TryGhost/NQL/tree/main/packages/mongo-knex",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/NQL.git",
+    "directory": "packages/mongo-knex"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "index.js",

--- a/packages/mongo-utils/package.json
+++ b/packages/mongo-utils/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/mongo-utils",
   "version": "0.6.4",
-  "repository": "https://github.com/TryGhost/NQL/tree/main/packages/mongo-utils",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/NQL.git",
+    "directory": "packages/mongo-utils"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "index.js",

--- a/packages/nql-lang/package.json
+++ b/packages/nql-lang/package.json
@@ -2,7 +2,11 @@
   "name": "@tryghost/nql-lang",
   "version": "0.6.5",
   "description": "tbc",
-  "repository": "https://github.com/TryGhost/NQL/tree/main/packages/nql-lang",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/NQL.git",
+    "directory": "packages/nql-lang"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "index.js",

--- a/packages/nql/package.json
+++ b/packages/nql/package.json
@@ -2,7 +2,11 @@
   "name": "@tryghost/nql",
   "version": "0.13.0",
   "description": "tbc",
-  "repository": "https://github.com/TryGhost/NQL/tree/main/packages/nql",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/NQL.git",
+    "directory": "packages/nql"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
refs https://github.com/lerna/lerna/issues/3273

## Why

Publishing from a local machine hit a dead end: npmjs.com no longer supports new TOTP (authenticator app) enrolments, and lerna's OTP prompt can't handle browser-based 2FA with security keys, so `yarn ship` failed at the npm publish step with no way to supply a one-time password.

## What changed

Follows the same pattern as [TryGhost/framework](https://github.com/TryGhost/framework):

- **`yarn ship` now only versions** — `lerna version` bumps, commits ("Published new versions"), tags, and pushes. No npm interaction happens locally anymore.
- **New `publish.yml` workflow** publishes to npm from CI using [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) with provenance — no tokens, no OTPs. It triggers on pushes to `main` that touch `packages/*/package.json` with a "Published new versions" commit message, or manually via `workflow_dispatch` (dry-run by default). It compares each package's `package.json` version against the registry and publishes only what's missing, so failed/partial publishes are retryable by re-running the workflow.
- **lerna config** — moved `allowBranch`/`message` under `command.version` so the standalone `lerna version` command picks them up.
- **`repository` fields** in all four packages rewritten from the `…/tree/main/packages/x` URL form to the canonical `{url, directory}` object form, which npm provenance validation requires.

The only structural difference from framework's workflow is the publish step: framework uses `nx release publish`, this runs `npm publish` per package directory — same effect without an nx migration.

## Reviewer notes / rollout

- **Before this can publish, each package needs a Trusted Publisher registered on npmjs.com** (`@tryghost/nql`, `@tryghost/nql-lang`, `@tryghost/mongo-knex`, `@tryghost/mongo-utils`): package Settings → Trusted Publisher → GitHub Actions, org `TryGhost`, repo `NQL`, workflow `publish.yml`, environment blank.
- Merging this PR won't trigger a publish (commit message doesn't match, and all current versions are already on the registry).
- Suggested smoke test after merging + registering publishers: run the workflow manually with dry-run enabled — it should report all four packages as "skip (already published)".