### PR TITLE
Fixed yarn cache handling in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,8 @@ jobs:
           persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        env:
+          FORCE_COLOR: 0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
The first dry-run of the Publish workflow ([run](https://github.com/TryGhost/NQL/actions/runs/27423660038/job/81055566068)) failed in the post-job cleanup with `Path Validation Error: Path(s) specified in the action for caching do(es) not exist`.

## Cause

The job-level `FORCE_COLOR: 1` env leaks into setup-node's internal `yarn cache dir` probe. With colors forced on, yarn 1 prefixes its output with ANSI escape codes, so setup-node recorded the cache path as `\e[2K\e[1G/home/runner/.cache/yarn/v6` — an invalid path. That broke both the cache restore at setup ("yarn cache is not found") and the cache save at teardown, marking the whole job red (and pinging Slack) even though every actual step succeeded.

## Fix

Override `FORCE_COLOR: 0` on the setup-node step, matching the existing workaround in test.yml. The framework repo's publish workflow doesn't need this because pnpm's cache-dir probe isn't affected.

Worth noting from that first dry-run: the publish logic itself behaved exactly as designed — all four packages were detected as already published and the publish step was skipped.