### PR TITLE
Add a `$elemMatch` operator for single related-row matching

### DIFF
--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -74,6 +74,18 @@ const aggregateOperatorError = relationName => new Error(`Aggregate relation "${
 //eslint-disable-next-line ghost/ghost-custom/no-native-error
 const aggregateColumnError = relationName => new Error(`Aggregate relation "${relationName}" is queried by name only, without a column (e.g. "${relationName}:0")`);
 
+//eslint-disable-next-line ghost/ghost-custom/no-native-error
+const elemMatchRelationError = key => new Error(`$elemMatch can only be used on a relation, not "${key}"`);
+
+//eslint-disable-next-line ghost/ghost-custom/no-native-error
+const elemMatchEmptyError = relationName => new Error(`$elemMatch on "${relationName}" needs at least one condition`);
+
+//eslint-disable-next-line ghost/ghost-custom/no-native-error
+const elemMatchOperatorError = (relationName, op) => new Error(`$elemMatch on "${relationName}" does not support the operator "${op}"`);
+
+//eslint-disable-next-line ghost/ghost-custom/no-native-error
+const elemMatchColumnError = (relationName, column) => new Error(`$elemMatch on "${relationName}" cannot use a dotted column ("${column}")`);
+
 /**
  * Whether an aggregate comparison would match a parent row with no related rows
  * (aggregate value 0). Such rows don't appear in the grouped subquery at all, so
@@ -174,6 +186,23 @@ class MongoToKnex {
         this.config = {};
 
         Object.assign(this.config, {relations: {}}, config);
+    }
+
+    /**
+     * Apply one comparison to a query builder. A regex reaches here only via a relation
+     * subquery — the top-level path handles it in buildComparison — so it is converted
+     * to the same LIKE-with-ESCAPE form that contains/startsWith/endsWith use, so they
+     * work on a related column too. Everything else is the plain
+     * `qb[whereType](column, op, value)` call.
+     */
+    applyComparison(builder, whereType, column, op, value) {
+        if (value instanceof RegExp) {
+            const {source, ignoreCase} = processRegExp(value);
+            const lhs = ignoreCase ? 'lower(??)' : '??';
+            return builder[`${whereType}Raw`](`${lhs} ${op} ? ESCAPE ?`, [column, source, likeEscapeCharacter]);
+        }
+
+        return builder[whereType](column, op, value);
     }
 
     processWhereType(mode, op, value) {
@@ -306,6 +335,22 @@ class MongoToKnex {
              */
             const isAggregate = statement.config && statement.config.type === 'aggregate';
 
+            // CASE: all conditions of one `$elemMatch` must match a single related
+            //       row, so they share a subquery keyed by the match's id regardless
+            //       of operator - the "a negation matches a different row" reasoning
+            //       below never applies to them. This is the explicit same-row escape
+            //       hatch: everything outside an $elemMatch keeps the default grouping.
+            if (statement.elemMatchGroup !== undefined) {
+                const elemKey = `${statement.table}_elem_${statement.elemMatchGroup}`;
+
+                if (!group[elemKey]) {
+                    group[elemKey] = {innerWhereStatements: []};
+                }
+
+                group[elemKey].innerWhereStatements.push(statement);
+                return;
+            }
+
             let shouldCreateSubGroup = !isAggregate && isNegationOp(statement.operator);
             if (!shouldCreateSubGroup && !isAggregate && group[statement.table]) {
                 shouldCreateSubGroup = _.some(group[statement.table].innerWhereStatements, (innerStatement) => {
@@ -362,6 +407,9 @@ class MongoToKnex {
      */
     buildRelationQuery(qb, relations, mode) {
         debug(`(buildRelationQuery)`);
+        // The subquery bodies below are knex callbacks where `this` is the query
+        // builder, so hold onto the converter to reach its helpers from inside them.
+        const self = this;
 
         if (debugExtended.enabled) {
             debugExtended(`(buildRelationQuery) ${stringify(relations)}`);
@@ -385,16 +433,26 @@ class MongoToKnex {
             if (reference.config.type === 'manyToMany') {
                 if (_.every(statements.map(s => s.operator), isCompOp)) {
                     // CASE: only negate whole group when all the operators in the group are negative,
-                    // otherwise we cannot combine groups with negated and regular equation operators
-                    const negateGroup = _.every(statements.map(s => s.operator), (operator) => {
-                        return isNegationOp(operator);
-                    });
+                    // otherwise we cannot combine groups with negated and regular equation operators.
+                    // Two distinct negations converge on a NOT IN outer membership:
+                    //   - legacyNegate: a group whose conditions are all negations (e.g. {$ne, $ne})
+                    //     and no $elemMatch. By De Morgan the whole group negates, and each inner
+                    //     condition flips to its positive form ($in) inside the subquery.
+                    //   - elemMatchNegate: a $not-wrapped $elemMatch. The whole single-row match is
+                    //     negated (parent.id NOT IN that subquery), but the conditions inside keep
+                    //     their literal operators — only the outer membership flips.
+                    // A positive $elemMatch negates neither: each condition applies within the one row.
+                    const legacyNegate = reference.elemMatchGroup === undefined
+                        && _.every(statements.map(s => s.operator), (operator) => {
+                            return isNegationOp(operator);
+                        });
+                    const negateGroup = reference.elemMatchNegate === true || legacyNegate;
 
                     const comp = negateGroup
                         ? compOps.$nin
                         : compOps.$in;
 
-                    const whereType = ['whereNull', 'whereNotNull'].includes(reference.whereType) ? 'andWhere' : (['orWhereNull', 'orWhereNotNull'].includes(reference.whereType) ? 'orWhere' : reference.whereType);
+                    const whereType = reference.outerWhereType || (['whereNull', 'whereNotNull'].includes(reference.whereType) ? 'andWhere' : (['orWhereNull', 'orWhereNotNull'].includes(reference.whereType) ? 'orWhere' : reference.whereType));
 
                     // CASE: WHERE resource.id (IN | NOT IN) (SELECT ...)
                     qb[whereType](`${this.tableName}.id`, comp, function () {
@@ -433,7 +491,7 @@ class MongoToKnex {
                             const statementColumn = `${statement.joinTable || statement.table}.${statement.column}`;
                             let statementOp;
 
-                            if (negateGroup) {
+                            if (legacyNegate) {
                                 statementOp = compOps.$in;
                             } else {
                                 if (isNegationOp(statement.operator)) {
@@ -450,7 +508,7 @@ class MongoToKnex {
                                 statementValue = !_.isArray(statement.value) ? [statement.value] : statement.value;
                             }
 
-                            innerQB[statement.whereType](statementColumn, statementOp, statementValue);
+                            self.applyComparison(innerQB, statement.whereType, statementColumn, statementOp, statementValue);
                         });
 
                         if (debugExtended.enabled) {
@@ -465,17 +523,27 @@ class MongoToKnex {
             } else if (reference.config.type === 'oneToOne') {
                 if (_.every(statements.map(s => s.operator), isCompOp)) {
                     // CASE: only negate whole group when all the operators in the group are negative,
-                    // otherwise we cannot combine groups with negated and regular equation operators
-                    const negateGroup = _.every(statements.map(s => s.operator), (operator) => {
-                        return isNegationOp(operator);
-                    });
+                    // otherwise we cannot combine groups with negated and regular equation operators.
+                    // Two distinct negations converge on a NOT IN outer membership:
+                    //   - legacyNegate: a group whose conditions are all negations (e.g. {$ne, $ne})
+                    //     and no $elemMatch. By De Morgan the whole group negates, and each inner
+                    //     condition flips to its positive form ($in) inside the subquery.
+                    //   - elemMatchNegate: a $not-wrapped $elemMatch. The whole single-row match is
+                    //     negated (parent.id NOT IN that subquery), but the conditions inside keep
+                    //     their literal operators — only the outer membership flips.
+                    // A positive $elemMatch negates neither: each condition applies within the one row.
+                    const legacyNegate = reference.elemMatchGroup === undefined
+                        && _.every(statements.map(s => s.operator), (operator) => {
+                            return isNegationOp(operator);
+                        });
+                    const negateGroup = reference.elemMatchNegate === true || legacyNegate;
 
                     const comp = negateGroup
                         ? compOps.$nin
                         : compOps.$in;
                     const tableName = this.tableName;
 
-                    const where = reference.whereType === 'orWhere' ? 'orWhere' : 'where';
+                    const where = (reference.outerWhereType || reference.whereType) === 'orWhere' ? 'orWhere' : 'where';
                     qb[where](`${this.tableName}.id`, comp, function () {
                         const joinFilterStatements = groupedRelations[key].joinFilterStatements;
 
@@ -507,9 +575,10 @@ class MongoToKnex {
                             const statementColumn = `${statement.table}.${statement.column}`;
                             let statementOp;
 
-                            // NOTE: this negation is here to ensure records with no relation are
-                            //       include in negation (e.g. `relation.columnName: {$ne: null})
-                            if (negateGroup) {
+                            // NOTE: this null flip ensures records with no relation are included in a
+                            //       De Morgan negation (e.g. `relation.columnName: {$ne: null}`). A
+                            //       $not $elemMatch keeps its conditions literal, so it does not flip.
+                            if (legacyNegate) {
                                 statementOp = compOps.$in;
 
                                 if (statement.value === null) {
@@ -530,7 +599,7 @@ class MongoToKnex {
                                 statementValue = !_.isArray(statement.value) ? [statement.value] : statement.value;
                             }
 
-                            innerQB[statement.whereType](statementColumn, statementOp, statementValue);
+                            self.applyComparison(innerQB, statement.whereType, statementColumn, statementOp, statementValue);
                         });
 
                         if (debugExtended.enabled) {
@@ -705,11 +774,7 @@ class MongoToKnex {
             }
 
             // CASE: if the statement is part of a group, collect the relation statements to be able to group them later
-            if (!Object.prototype.hasOwnProperty.call(qb, 'relations')) {
-                qb.relations = [];
-            }
-
-            qb.relations.push(processedStatement);
+            this.collectRelationStatements(qb, [processedStatement]);
             return;
         }
 
@@ -736,7 +801,7 @@ class MongoToKnex {
         }
 
         debug(`(buildComparison) whereType: ${whereType}, statement: ${statement}, op: ${op}, comp: ${comp}, value: ${value}`);
-        qb[whereType](column, comp, value);
+        this.applyComparison(qb, whereType, column, comp, value);
     }
 
     /**
@@ -758,12 +823,79 @@ class MongoToKnex {
         //       (unknown operators on aggregate relations were already rejected by
         //       the validateAggregateStatements pre-pass in processJSON)
         _.forIn(sub, (value, op) => {
-            if (isCompOp(op)) {
+            if (op === '$elemMatch') {
+                this.buildElemMatch(qb, mode, statement, value, group, false);
+            } else if (op === '$not' && _.isObject(value) && value.$elemMatch) {
+                // `{relation: {$not: {$elemMatch: {…}}}}` negates the single-row match:
+                // no related row satisfies all the conditions (parent.id NOT IN …).
+                this.buildElemMatch(qb, mode, statement, value.$elemMatch, group, true);
+            } else if (isCompOp(op)) {
                 this.buildComparison(qb, mode, statement, op, value, group);
             } else {
                 debug('unknown operator');
             }
         });
+    }
+
+    /**
+     * `{relation: {$elemMatch: {col: value, otherCol: {$ne: x}}}}`
+     *
+     * Match a single related row against all of the given conditions at once,
+     * emitted as one correlated subquery (`parent.id IN (SELECT … WHERE cond AND
+     * cond …)`). Without it, each condition on a multi-row relation is an
+     * independent existence check - a negation in particular becomes its own
+     * `NOT IN`, so a discriminator+value pair like `key = 'company' AND value != 'x'`
+     * would match different rows. `$elemMatch` is the explicit way to say the whole
+     * group describes one row; everything outside it keeps the default per-condition
+     * grouping untouched.
+     */
+    buildElemMatch(qb, mode, relationName, conditions, group, negate = false) {
+        // The relation, the non-empty-object shape, and the inner operators have already
+        // been validated by validateElemMatchStatements during conversion, so this builds
+        // from conditions it can trust.
+        const collector = {};
+        const elemMatchGroup = (this.elemMatchSeq = (this.elemMatchSeq || 0) + 1);
+
+        // Inner conditions are always ANDed - a single row satisfies all of them - so
+        // process them as an $and regardless of the mode the match itself sits in. Each
+        // inner key names a column on the related row.
+        _.forIn(conditions, (conditionValue, conditionColumn) => {
+            this.buildWhereClause(collector, '$and', `${relationName}.${conditionColumn}`, conditionValue, true);
+        });
+
+        const statements = collector.relations || [];
+
+        statements.forEach((statement) => {
+            statement.elemMatchGroup = elemMatchGroup;
+            statement.elemMatchNegate = negate;
+        });
+
+        // The subquery attaches to the outer query with the outer mode's conjunction.
+        // Carried out-of-band on the first statement rather than overwriting its
+        // whereType, which still drives its own inner comparison — a null condition
+        // needs its whereNull left in place, or it degrades to `= NULL`.
+        if (mode === '$or' && statements.length) {
+            statements[0].outerWhereType = 'orWhere';
+        }
+
+        // CASE: not part of an outer group - attach the subquery immediately.
+        if (!group) {
+            this.buildRelationQuery(qb, statements, mode);
+            return;
+        }
+
+        // CASE: part of a group - hand the statements to the group's relation flush
+        //       so the subquery composes with sibling relation filters.
+        this.collectRelationStatements(qb, statements);
+    }
+
+    // Stash relation statements on the builder for the group's deferred relation
+    // flush (see buildWhereGroup), lazily creating the list on first use.
+    collectRelationStatements(qb, statements) {
+        if (!Object.prototype.hasOwnProperty.call(qb, 'relations')) {
+            qb.relations = [];
+        }
+        qb.relations.push(...statements);
     }
 
     /**
@@ -865,6 +997,72 @@ class MongoToKnex {
         });
     }
 
+    // Walks the filter for $elemMatch clauses (bare or wrapped in $not) and validates
+    // each one. Raised here, before query building, so a match nested in an $and/$or
+    // group fails at conversion rather than deep inside a knex where-callback at render
+    // time — the same reason validateAggregateStatements exists.
+    validateElemMatchStatements(sub) {
+        if (!_.isPlainObject(sub)) {
+            return;
+        }
+
+        _.forIn(sub, (value, key) => {
+            if (isLogicOp(key)) {
+                _.castArray(value).forEach(group => this.validateElemMatchStatements(group));
+                return;
+            }
+
+            if (isOp(key) || !_.isPlainObject(value)) {
+                return;
+            }
+
+            const conditions = value.$elemMatch !== undefined
+                ? value.$elemMatch
+                : (_.isPlainObject(value.$not) ? value.$not.$elemMatch : undefined);
+
+            if (conditions !== undefined) {
+                this.validateElemMatch(key, conditions);
+            }
+        });
+    }
+
+    validateElemMatch(relationName, conditions) {
+        if (!this.config.relations[relationName]) {
+            throw elemMatchRelationError(relationName);
+        }
+
+        // A non-object (string, number, array) would iterate as bogus columns; an empty
+        // one places no constraint and silently widens the result to every parent.
+        if (!_.isPlainObject(conditions) || _.isEmpty(conditions)) {
+            throw elemMatchEmptyError(relationName);
+        }
+
+        _.forIn(conditions, (conditionValue, conditionColumn) => {
+            // A condition names a column, not an operator: a logical or nested operator in
+            // the match body (e.g. $or, a nested $elemMatch) is a non-goal, not a column.
+            if (isOp(conditionColumn)) {
+                throw elemMatchOperatorError(relationName, conditionColumn);
+            }
+
+            // A dotted key would be split by processStatement into relation.column and lose
+            // every segment after the first, silently comparing a different column.
+            if (conditionColumn.includes('.')) {
+                throw elemMatchColumnError(relationName, conditionColumn);
+            }
+
+            // Each operator applied to that column must be one the subquery can compile,
+            // so a typo'd operator is rejected rather than silently dropped — which would
+            // leave fewer conditions in place and widen the single-row match.
+            if (_.isPlainObject(conditionValue)) {
+                _.forIn(conditionValue, (operatorValue, op) => {
+                    if (!isCompOp(op)) {
+                        throw elemMatchOperatorError(relationName, op);
+                    }
+                });
+            }
+        });
+    }
+
     /**
      * The converter receives sub query objects e.g. `qb.where('..', (qb) => {})`, which
      * we then pass around to our class methods. That's why we pass the parent `qb` object
@@ -879,6 +1077,7 @@ class MongoToKnex {
         }
 
         this.validateAggregateStatements(mongoJSON);
+        this.validateElemMatchStatements(mongoJSON);
 
         // 'and' is the default behaviour
         this.buildQuery(qb, '$and', mongoJSON);

--- a/packages/mongo-knex/test/integration/relations.test.js
+++ b/packages/mongo-knex/test/integration/relations.test.js
@@ -126,6 +126,16 @@ describe('Relations', function () {
                     });
             });
 
+            // A regex (contains/startsWith/endsWith) on a related column compiles to
+            // LIKE. Executed here because the base converter emitted invalid SQL for
+            // this shape (a stringified RegExp) and matched nothing - a real, shipped
+            // NQL filter shape (e.g. `tags.slug:~'ani'`), so the fix is pinned end to end.
+            it('matches a related column by a startsWith regex', function () {
+                return makeQuery({'tags.slug': {$regex: /^ani/}})
+                    .select()
+                    .then(result => result.should.matchIds([2, 4, 6]));
+            });
+
             it('tags.visibility equals "internal"', function () {
                 const mongoJSON = {
                     'tags.visibility': 'internal'
@@ -1096,6 +1106,17 @@ describe('Relations', function () {
     });
 
     describe('One-to-One', function () {
+        // A $not-wrapped $elemMatch excludes rows that HAVE a matching related row, so
+        // it also matches parents with no related row at all — proven here by execution
+        // (the NOT IN semantics differ from a positive match, and only real rows show it).
+        describe('$not $elemMatch (no matching related row)', function () {
+            it('excludes posts whose meta_title matches, keeping the rest', function () {
+                return makeQuery({posts_meta: {$not: {$elemMatch: {meta_title: 'Meta of Circle of Life'}}}})
+                    .select()
+                    .then(result => result.should.matchIds([1, 2, 3, 5, 6, 7, 8]));
+            });
+        });
+
         describe('EQUALS $eq', function () {
             it('posts_meta.meta_title equals "Meta of A Whole New World"', function () {
                 const mongoJSON = {

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -824,3 +824,110 @@ describe('RegExp/Like queries', function () {
             .should.eql('select * from `posts` where lower(`posts`.`title`) like \'%\\\';select ** from `settings` where `value` like \\\'%\' ESCAPE \'*\'');
     });
 });
+
+describe('$elemMatch (single related row)', function () {
+    // $elemMatch collapses all its conditions into ONE subquery, so a
+    // discriminator+value pair like `meta_title = 'A' AND meta_description != 'B'`
+    // matches a single related row rather than splitting the negation into an
+    // independent NOT IN. This is the explicit same-row escape hatch.
+    it('matches a discriminator and a negated value on the same one-to-one row', function () {
+        runQuery({posts_meta: {$elemMatch: {meta_title: 'A', meta_description: {$ne: 'B'}}}})
+            .should.eql('select * from `posts` where `posts`.`id` in (select `posts`.`id` from `posts` left join `posts_meta` on `posts_meta`.`post_id` = `posts`.`id` where `posts_meta`.`meta_title` = \'A\' and `posts_meta`.`meta_description` not in (\'B\'))');
+    });
+
+    // $elemMatch is relation-agnostic: it forces same-row matching on a many-to-many
+    // relation too (one tag that is both slug 'a' and not internal).
+    it('matches a single row of a many-to-many relation', function () {
+        runQuery({tags: {$elemMatch: {slug: 'a', visibility: {$ne: 'internal'}}}})
+            .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = \'a\' and `tags`.`visibility` not in (\'internal\'))');
+    });
+
+    // Without $elemMatch the default grouping is unchanged: a negation on a plain
+    // $and is still an independent "no row matches" subquery (has tag a AND not tag b).
+    it('leaves the default per-condition grouping untouched outside $elemMatch', function () {
+        runQuery({$and: [{'tags.slug': 'a'}, {'tags.slug': {$ne: 'b'}}]})
+            .should.eql('select * from `posts` where (`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = \'a\') and `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` in (\'b\')))');
+    });
+
+    // Two independent $elemMatch groups compose under OR.
+    it('composes multiple matches under $or', function () {
+        runQuery({$or: [{posts_meta: {$elemMatch: {meta_title: 'A', meta_description: 'B'}}}, {posts_meta: {$elemMatch: {meta_title: 'C', meta_description: 'D'}}}]})
+            .should.eql('select * from `posts` where (`posts`.`id` in (select `posts`.`id` from `posts` left join `posts_meta` on `posts_meta`.`post_id` = `posts`.`id` where `posts_meta`.`meta_title` = \'A\' and `posts_meta`.`meta_description` = \'B\') or `posts`.`id` in (select `posts`.`id` from `posts` left join `posts_meta` on `posts_meta`.`post_id` = `posts`.`id` where `posts_meta`.`meta_title` = \'C\' and `posts_meta`.`meta_description` = \'D\'))');
+    });
+
+    // An all-negation match stays positive: "has a tag that is neither a nor b" —
+    // one row where both conditions hold. It must NOT invert to a NOT IN subquery
+    // ("has no tag that is both a and b"), which is a different set.
+    it('keeps an all-negation match positive rather than inverting to NOT IN', function () {
+        runQuery({tags: {$elemMatch: {slug: {$ne: 'a'}, visibility: {$ne: 'b'}}}})
+            .should.eql('select * from `posts` where `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` not in (\'a\') and `tags`.`visibility` not in (\'b\'))');
+    });
+
+    // The guards fire at conversion (buildQuery), before any SQL is rendered, so a
+    // consumer's filter-parse error handling catches them — hence buildQuery, not runQuery.
+    it('throws on an empty match rather than dropping the constraint', function () {
+        (() => buildQuery({tags: {$elemMatch: {}}})).should.throw(/needs at least one condition/);
+    });
+
+    it('throws when used on a non-relation key', function () {
+        (() => buildQuery({title: {$elemMatch: {foo: 'x'}}})).should.throw(/can only be used on a relation/);
+    });
+
+    it('throws when used on an aggregate relation', function () {
+        (() => buildQuery({tag_count: {$elemMatch: {slug: 'a'}}})).should.throw(/[Aa]ggregate relation/);
+    });
+
+    it('throws on a non-object match value rather than iterating it', function () {
+        (() => buildQuery({tags: {$elemMatch: 'a'}})).should.throw(/needs at least one condition/);
+    });
+
+    // Nested in an $and group, the guard still fires at conversion, not deferred into a
+    // knex where-callback that only runs at render (which would be a 500, not a 4xx).
+    it('throws at conversion for a match nested inside a group', function () {
+        (() => buildQuery({$and: [{status: 'draft'}, {tags: {$elemMatch: {}}}]})).should.throw(/needs at least one condition/);
+    });
+
+    // An unrecognised inner operator is rejected, not silently dropped — dropping it would
+    // leave `{key:'company', value:{$typo:'x'}}` matching every member with a company field.
+    it('throws on an unrecognised operator inside the match', function () {
+        (() => buildQuery({tags: {$elemMatch: {slug: 'a', visibility: {$bogus: 'x'}}}})).should.throw(/does not support the operator/);
+    });
+
+    it('throws on a logical operator inside the match body', function () {
+        (() => buildQuery({tags: {$elemMatch: {$or: [{slug: 'a'}, {slug: 'b'}]}}})).should.throw(/does not support the operator/);
+    });
+
+    // A dotted key would be truncated to relation.column by processStatement, silently
+    // comparing a different column, so it is rejected rather than run.
+    it('throws on a dotted column inside the match', function () {
+        (() => buildQuery({posts_meta: {$elemMatch: {'meta_title.sub': 'x'}}})).should.throw(/cannot use a dotted column/);
+    });
+
+    // The outer $or must not clobber a null condition's IS NULL: the match's first
+    // condition here is a null, and it has to stay `is null`, not become `= NULL`.
+    it('keeps a null condition literal when the match sits under $or', function () {
+        runQuery({$or: [{status: 'draft'}, {posts_meta: {$elemMatch: {meta_title: null, meta_description: 'd'}}}]})
+            .should.eql('select * from `posts` where (`posts`.`status` = \'draft\' or `posts`.`id` in (select `posts`.`id` from `posts` left join `posts_meta` on `posts_meta`.`post_id` = `posts`.`id` where `posts_meta`.`meta_title` is null and `posts_meta`.`meta_description` = \'d\'))');
+    });
+
+    // A $not-wrapped $elemMatch negates the whole single-row match: no related row
+    // satisfies all the conditions, emitted as parent.id NOT IN that same subquery.
+    it('negates the single-row match with $not (NOT IN) on a one-to-one relation', function () {
+        runQuery({posts_meta: {$not: {$elemMatch: {meta_title: 'A', meta_description: 'B'}}}})
+            .should.eql('select * from `posts` where `posts`.`id` not in (select `posts`.`id` from `posts` left join `posts_meta` on `posts_meta`.`post_id` = `posts`.`id` where `posts_meta`.`meta_title` = \'A\' and `posts_meta`.`meta_description` = \'B\')');
+    });
+
+    it('negates a single-condition match with $not on a many-to-many relation', function () {
+        runQuery({tags: {$not: {$elemMatch: {slug: 'a'}}}})
+            .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = \'a\')');
+    });
+
+    // The negation is only the outer membership: the conditions inside keep their literal
+    // operators, so a non-equality condition survives. Forcing them to $in (as the
+    // De Morgan path does) would silently drop the operator — here it would ask for "no
+    // tag whose slug IS a" instead of "no tag whose slug is NOT a".
+    it('keeps inner operators literal under a $not $elemMatch', function () {
+        runQuery({tags: {$not: {$elemMatch: {slug: {$ne: 'a'}}}}})
+            .should.eql('select * from `posts` where `posts`.`id` not in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` not in (\'a\'))');
+    });
+});


### PR DESCRIPTION
This PR adds one operator; the description is its specification, and the single commit implements it.

---

## Abstract

`$elemMatch` is an operator for mongo-knex relation filters that constrains all of its conditions to be satisfied by a *single* related row, with a `$not`-wrapped negation asserting that *no* related row satisfies them. It is additive: filters that do not use `$elemMatch` are unchanged, apart from one carried bug-fix noted under Compatibility.

## Motivation

mongo-knex compiles a filter on a to-many relation into a correlated subquery over the related table. When a filter places more than one condition on the same relation under `$and`, each condition becomes an *independent* existence check:

```js
{ tags: { slug: 'a', visibility: 'public' } }
// parent has a tag slugged 'a'  AND  parent has a (possibly different) public tag
```

For most relations that independence is correct — a post genuinely may satisfy the two through different tags. But when a relation stores **rows of attributes** — an entity-attribute-value shape such as `(key, value)` pairs — the independence is wrong. "The row whose key is `country` has value `GB`" is a claim about *one* row:

```js
{ custom_fields: { key: 'country', value: 'GB' } }
// WRONG: matches a member who has a `country` field AND, separately, any field valued 'GB'
```

Before `$elemMatch` there was no way to say "these conditions describe one row".

## Specification

### Positive form

```js
{ <relation>: { $elemMatch: { <cond>, <cond>, ... } } }
```

The parent matches iff **at least one** related row satisfies **all** of the conditions. It compiles to a single membership subquery, `parent.id IN (…)`.

### Negated form

```js
{ <relation>: { $not: { $elemMatch: { <cond>, ... } } } }
```

The parent matches iff **no** related row satisfies all of the conditions. It compiles to the *same* subquery, attached as `parent.id NOT IN (…)`.

The negation flips **only** the outer membership (`IN` → `NOT IN`). Every inner condition keeps its own operator: a `$ne`, a range, a regex, or a null inside a negated `$elemMatch` is applied literally within the subquery. This is what distinguishes `$not: { $elemMatch }` from the pre-existing all-negation grouping (see Rationale).

### The subquery, per relation type

The correlated subquery ranges over the rows of the related table joined to the parent, and never over the "no related row" case — that case is handled by membership, not by the row set. Its exact shape follows mongo-knex's existing relation conventions:

- **`manyToMany`** — `SELECT <joinTable>.<joinFrom> FROM <joinTable> JOIN <related> … WHERE <conds>`. The selected `joinFrom` is the join table's foreign key to the parent; it references the parent's primary key and is therefore non-null (see the NOT IN note under Rationale).
- **`oneToOne`** — `SELECT <parent>.id FROM <parent> LEFT JOIN <related> … WHERE <conds>`. The membership is over parent ids, which are non-null.

### Conditions

Each `<cond>` is an ordinary mongo-knex leaf condition on a **column of the related row**, combined with the others by `AND`. The accepted operators are exactly those available at the top level of a relation filter:

- equality, `$ne`, `$in`, `$nin`;
- the range operators `$gt` / `$gte` / `$lt` / `$lte`;
- a regular expression, **restricted to the library's contains / starts-with / ends-with subset** (compiled to `LIKE … ESCAPE`; an `i` flag lowers both sides). Alternation, character classes and quantifiers are not supported and are treated as literal text, consistent with the rest of mongo-knex.

Values are bound as given; the database's own coercion rules apply to the comparison (as everywhere else in mongo-knex).

### Null conditions

A null inner condition compiles to `IS NULL` (equality) or `IS NOT NULL` (`$ne`) on the related column. On a `oneToOne` relation the subquery is a `LEFT JOIN`, so a parent with **no** related row also produces `NULL` for that column and is therefore indistinguishable from one whose row holds a null — an `IS NULL` inner condition matches both. A caller that needs strict presence semantics should assert on a column that is non-null whenever the row exists (e.g. the `key` of an EAV row), not probe an arbitrary column for null.

## Errors

All of these are raised **during conversion**, before any SQL is rendered, so a consumer's filter-parsing error handling turns them into a client error rather than a query-time failure — including when the `$elemMatch` sits inside an `$and` / `$or` group.

- **Non-object or empty match.** The value of `$elemMatch` must be a plain object with at least one condition. A non-object (string, number, array) or an empty object throws — otherwise a string would iterate as character-indexed columns, and an empty object would place no constraint and silently widen the result to every parent.
- **Unrecognised inner operator.** An operator inside the match that the subquery cannot compile — a typo like `{$typ: 'x'}`, or a logical operator such as `$or` in the body — throws, rather than being silently dropped. Dropping even one condition would remove a constraint and widen the single-row match.
- **Non-relation target.** `$elemMatch` on a key that is not a configured relation throws — there is no related table to range over.
- **Aggregate relation.** `$elemMatch` on an `aggregate`-configured relation throws (via the aggregate pre-pass): an aggregate compares one computed value and has no row to match.

## Non-goals

These are deliberately excluded and **rejected at conversion** — a filter that uses them throws rather than being silently reinterpreted:

- **Logical operators inside the match body.** `{ $elemMatch: { $or: […] } }`, `$and`, and a nested `$elemMatch` are not supported — each inner key is a column, not a combinator. This diverges from MongoDB, which accepts `$or` inside `$elemMatch`.
- **OR across the conditions of one row.** There is no way to say "one row satisfying A **or** B". OR *across rows* is expressible as a top-level `$or` of two `$elemMatch` clauses; OR *within* the candidate row is not.
- **`$not` on a relation key other than around `$elemMatch`.** The negated form is specifically `{ <relation>: { $not: { $elemMatch: … } } }`. `$not` wrapping any other value on a relation key is not defined by this operator.
- **Dotted or join-table-qualified columns inside the match body.** A condition names a single column of the related row; a dotted key is rejected, since it would otherwise be truncated to a different column. (Sibling join-table filters placed *alongside* the relation under `$and` still attach to the subquery, as they do for any relation filter.)

## Semantics summary

- **Conjunction over one row.** Every condition applies to the same candidate row; the parent matches on the existence (positive) or non-existence (negated) of such a row.
- **Parents with no related rows.** A `$not: { $elemMatch }` matches a parent that has no related rows at all — vacuously, none of its rows satisfies the conditions. A positive `$elemMatch` never matches such a parent.
- **Single condition.** `{ $elemMatch: { a: 1 } }` is semantically identical to the plain `{ a: 1 }` relation filter; the operator is still accepted, so a caller can build the shape uniformly.
- **Composition.** An `$elemMatch` clause composes with any other filter under `$and` / `$or` exactly like any other relation clause; two `$elemMatch` clauses on the same relation are two independent single-row assertions.

## Rationale

- **Why an operator, not a heuristic.** Whether conditions describe one row or many is a property of the *query*, not of the relation, so it cannot be inferred from the schema. The caller states it explicitly.
- **Why the name.** It mirrors MongoDB's `$elemMatch`, which has the same "one element of the array satisfies all conditions" meaning. (mongo-knex diverges on the degenerate `{ $elemMatch: {} }`, which MongoDB accepts and this operator rejects, and on logical operators in the body — see Non-goals.)
- **Why `$not: { $elemMatch }` for negation.** It reads as the plain negation of the positive claim and reuses its exact subquery, so the two forms cannot drift.
- **Why only the outer membership flips.** mongo-knex already collapses an all-negation relation group (`{ a: {$ne}, b: {$ne} }`, no `$elemMatch`) into one `NOT IN` by De Morgan, positivizing each inner operator. Applying that to a negated `$elemMatch` would rewrite `value != 'x'` into `value IN ('x')` and drop the operator's meaning. `$elemMatch` keeps its inner operators literal in both forms; the two negations are kept distinct in the compiler.
- **Why the `NOT IN` form is safe.** `NOT IN` over a subquery collapses to no matches if the subquery yields a NULL. The negated form selects the parent's primary key (`oneToOne`) or the join table's foreign key to it (`manyToMany`); both reference a primary key and are non-null in any valid relation config, so the "no related row ⇒ match" guarantee holds. A relation configured to select a nullable correlation key would break it — that is a malformed config, out of scope here.

## Compatibility

Additive, with one carried fix. Relations filtered without `$elemMatch` keep their independent-existence semantics, and the all-negation grouping is untouched. The single behaviour change is a bug fix the operator depends on: a regular expression on a relation column (e.g. `tags.slug: {$regex: /^a/}`) previously emitted invalid SQL and matched nothing; it now compiles to the same `LIKE … ESCAPE` form used everywhere else.

---

*This PR previously also carried a JSON-path-extraction change. The consuming feature (Ghost member custom fields) moved to normalised leaf-row storage and no longer needs it, so it was removed and the history rewritten to leave `$elemMatch` as the single, focused addition.*
