### PR TITLE
Harden publish dependency installation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
           cache: yarn
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --prefer-offline
+        run: yarn install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Build releasable packages
         run: yarn build


### PR DESCRIPTION
## What changed

- disable dependency lifecycle scripts during the frozen Yarn install in the npm publish job
- keep the existing OIDC trusted-publishing and provenance configuration unchanged

## Why

The publish job has id-token write permission, so allowing arbitrary dependency lifecycle scripts during installation gives compromised transitive dependencies code execution in a privileged release context. Yarn's ignore-scripts flag makes that install fail closed without changing the non-privileged test workflow.

Tracks [PLA-315](https://linear.app/ghost/issue/PLA-315/harden-nqls-privileged-publish-dependency-installation).

## Validation

- yarn install --frozen-lockfile --prefer-offline --ignore-scripts
- yarn build
- npm publish --dry-run for all four workspaces
- git diff --check

The full local test suite was also attempted from the scripts-disabled install. SQLite-backed tests cannot load sqlite3 because its native binding is installed by a lifecycle script; this is expected for the hardened publish environment, which only builds releasable packages. The ordinary test workflow remains unchanged and continues to install the binding.