### PR TITLE
Fix the publish workflow failing before it can publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,6 @@ jobs:
           FORCE_COLOR: 0
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
           cache: yarn
 
       - name: Install dependencies


### PR DESCRIPTION
## Problem

The Publish workflow fails in ~12s at the `setup-node` step with `Failed to replace env in config: ${NODE_AUTH_TOKEN}`, so nothing publishes even after a `Published new versions` commit lands on `main`.

`actions/setup-node`'s `registry-url` writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`; the following `yarn install --frozen-lockfile` tries to resolve that variable and dies, because the repo publishes via OIDC (trusted publishing) and never sets that token.

## Solution

Remove `registry-url` from the `setup-node` step. Installing the public `@tryghost` packages needs no auth, the registry is already configured token-free in the later "Configure npm registry" step, and OIDC provides authentication for `npm publish`. No token is reintroduced.

After merge, re-run the release via **Actions → Publish → Run workflow** (dry-run off): the "Determine packages to publish" step publishes the versions on `main` that aren't yet on npm.
