### PR TITLE
🎨 Removed date-fns dependency

### DIFF
--- a/packages/nql-lang/lib/scope.js
+++ b/packages/nql-lang/lib/scope.js
@@ -1,12 +1,6 @@
 const util = require('util');
 
-const add = require('date-fns/add');
-const sub = require('date-fns/sub');
-
-const ops = {
-    add,
-    sub
-};
+const {DateTime} = require('luxon');
 
 const intervals = {
     d: 'days',
@@ -18,21 +12,10 @@ const intervals = {
     s: 'seconds'
 };
 
-/**
- * Return a string "year-month-day hours:minutes:seconds"
- * This format works for both SQLite3 and MySQL when used with >
- * We don't use date-fns format because it always outputs local time and we want UTC
- * This is a bit of a hack, but it's the least amount of code that gives us the right thing
- * @TODO: add proper tests for this
- *
- * @param {Date} date
- * @returns {String} formattedDate in the form "year-month-day hours:minutes:seconds"
- */
-const formatDateForSQL = (date) => {
-    const isoDate = date.toISOString();
-    // Replace the T with a space, and strip the milliseconds and timezone from the end of the string
-    return isoDate.replace('T', ' ').replace(/\.[0-9]{3}Z/, '');
-};
+// "year-month-day hours:minutes:seconds", which works for both SQLite3 and
+// MySQL when used with >. Note that `toSQL()` looks like the obvious call here
+// but appends milliseconds, which we don't want.
+const SQL_FORMAT = 'yyyy-MM-dd HH:mm:ss';
 
 module.exports = {
     ungroup(value) {
@@ -65,10 +48,15 @@ module.exports = {
             return {$relativeDate: {op, amount: Number(amount), unit: intervals[duration]}};
         }
 
-        const now = new Date();
-        const relDate = ops[op](now, {[intervals[duration]]: amount});
+        // Resolve against UTC explicitly. The output is compared against stored
+        // UTC timestamps, so the calendar arithmetic has to happen in UTC too -
+        // doing it in the server's local zone makes "now-1d" 23 or 25 hours
+        // either side of a DST transition.
+        const now = DateTime.utc();
+        const relDuration = {[intervals[duration]]: Number(amount)};
+        const relDate = op === 'add' ? now.plus(relDuration) : now.minus(relDuration);
 
-        return formatDateForSQL(relDate);
+        return relDate.toFormat(SQL_FORMAT);
     },
 
     debug() {

--- a/packages/nql-lang/package.json
+++ b/packages/nql-lang/package.json
@@ -32,6 +32,6 @@
     "sinon": "22.1.0"
   },
   "dependencies": {
-    "date-fns": "2.30.0"
+    "luxon": "^3.7.2"
   }
 }

--- a/packages/nql-lang/test/scope.test.js
+++ b/packages/nql-lang/test/scope.test.js
@@ -1,5 +1,6 @@
 require('./utils');
 
+const sinon = require('sinon');
 const scope = require('../lib/scope');
 
 describe('Scope date helpers', function () {
@@ -7,6 +8,64 @@ describe('Scope date helpers', function () {
         const result = scope.relDateToAbsolute('sub', 1, 'd');
 
         result.should.match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    });
+
+    describe('date arithmetic', function () {
+        let clock;
+
+        const freezeAt = (iso) => {
+            clock = sinon.useFakeTimers(new Date(iso).getTime());
+        };
+
+        afterEach(function () {
+            if (clock) {
+                clock.restore();
+                clock = undefined;
+            }
+        });
+
+        it('shifts by each unit', function () {
+            freezeAt('2021-05-15T18:45:12Z');
+
+            scope.relDateToAbsolute('add', 30, 's').should.eql('2021-05-15 18:45:42');
+            scope.relDateToAbsolute('add', 20, 'm').should.eql('2021-05-15 19:05:12');
+            scope.relDateToAbsolute('sub', 19, 'h').should.eql('2021-05-14 23:45:12');
+            scope.relDateToAbsolute('add', 20, 'd').should.eql('2021-06-04 18:45:12');
+            scope.relDateToAbsolute('sub', 3, 'w').should.eql('2021-04-24 18:45:12');
+            scope.relDateToAbsolute('add', 2, 'M').should.eql('2021-07-15 18:45:12');
+            scope.relDateToAbsolute('sub', 3, 'y').should.eql('2018-05-15 18:45:12');
+        });
+
+        it('clamps to the last day of the month rather than overflowing', function () {
+            // 31 Jan + 1 month is 28 Feb, not 3 Mar
+            freezeAt('2021-01-31T12:00:00Z');
+            scope.relDateToAbsolute('add', 1, 'M').should.eql('2021-02-28 12:00:00');
+            clock.restore();
+
+            // ...and 29 Feb in a leap year
+            freezeAt('2024-01-31T12:00:00Z');
+            scope.relDateToAbsolute('add', 1, 'M').should.eql('2024-02-29 12:00:00');
+            clock.restore();
+
+            // 29 Feb - 1 year is 28 Feb
+            freezeAt('2024-02-29T12:00:00Z');
+            scope.relDateToAbsolute('sub', 1, 'y').should.eql('2023-02-28 12:00:00');
+        });
+
+        it('resolves against UTC, not the local time zone', function () {
+            // A DST transition in the host zone must not change the result:
+            // 2026-03-08 07:00Z is the US spring-forward
+            freezeAt('2026-03-08T12:00:00Z');
+
+            scope.relDateToAbsolute('sub', 1, 'd').should.eql('2026-03-07 12:00:00');
+        });
+
+        it('returns the current time when the amount is zero', function () {
+            freezeAt('2021-05-15T18:45:12Z');
+
+            scope.relDateToAbsolute('add', 0, 'd').should.eql('2021-05-15 18:45:12');
+            scope.relDateToAbsolute('sub', 0, 'M').should.eql('2021-05-15 18:45:12');
+        });
     });
 
     it('supports all interval units', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,11 +25,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
   integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
-"@babel/runtime@^7.21.0":
-  version "7.29.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
-  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
-
 "@bcoe/v8-coverage@^1.0.1":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
@@ -1677,13 +1672,6 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-date-fns@2.30.0:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
-  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
-
 debug@4, debug@4.4.3, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
@@ -3317,6 +3305,11 @@ lru.min@^1.1.0, lru.min@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/lru.min/-/lru.min-1.1.4.tgz#6ea1737a8c1ba2300cc87ad46910a4bdffa0117b"
   integrity sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==
+
+luxon@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.7.2.tgz#d697e48f478553cca187a0f8436aff468e3ba0ba"
+  integrity sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==
 
 make-dir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
no ref
- date-fns is 24mb/2k+ files, pulled in as a dep specifically for add/sub functions
- because nql uses a limited subset of functionality, we replicate it in-repo rather than pull in the extra dep

note: date-fns makes a lot of sense for tree-shakeable frontend code that's bundled, not so much for server-side code that isn't