### PR TITLE
🐛 Fixed filters losing values that contain ^ or $

### DIFF
--- a/packages/mongo-knex/lib/convertor.js
+++ b/packages/mongo-knex/lib/convertor.js
@@ -119,10 +119,40 @@ const stringify = (json) => {
     });
 };
 
+/**
+ * Whether a trailing `$` anchors the pattern, rather than being a dollar in the value.
+ *
+ * A value containing a dollar arrives escaped, as `5\$`, which still ends in `$`. An odd run
+ * of backslashes before it means it is escaped and so part of the value.
+ */
+const hasEndAnchor = (source) => {
+    if (!source.endsWith('$')) {
+        return false;
+    }
+
+    let backslashes = 0;
+
+    for (let index = source.length - 2; index >= 0 && source[index] === '\\'; index -= 1) {
+        backslashes += 1;
+    }
+
+    return backslashes % 2 === 0;
+};
+
 const processRegExp = ({source, ignoreCase}) => {
     // A regexp is transformed into a LIKE SQL query.
-    // So we need to remove all the regexp escaped characters
-    // We don't support any special regexp operators apart from startsWith and endsWith (or both) queries
+    // We don't support any special regexp operators apart from startsWith and endsWith (or both).
+    //
+    // The anchors have to be read before the escaped characters are removed, not after. A value
+    // holding a literal `^` or `$` reaches here escaped — `\^abc`, `abc\$` — and unescaping
+    // first makes it indistinguishable from the anchor of the same name, so `contains 'abc$'`
+    // would compile to the same LIKE pattern as `endsWith 'abc'`.
+    const startAnchor = source.startsWith('^');
+    const endAnchor = hasEndAnchor(source);
+
+    source = source.slice(startAnchor ? 1 : 0, endAnchor ? -1 : undefined);
+
+    // Now that the anchors are accounted for, what is left is the value itself.
     source = source.replace(/\\([.*+?^${}()|[\]\\/])/g, '$1');
 
     if (ignoreCase) {
@@ -136,13 +166,15 @@ const processRegExp = ({source, ignoreCase}) => {
     source = source.replace(/%/g, likeEscapeCharacter + '%');
     source = source.replace(/_/g, likeEscapeCharacter + '_');
 
-    // For starts with and ends with in SQL we have to put the wildcard at the opposite end of the string to the regex symbol!
-    if (source.startsWith('^')) {
-        source = source.substring(1) + '%';
-    } else if (source.endsWith('$')) {
-        source = '%' + source.substring(0, source.length - 1);
-    } else {
-        source = '%' + source + '%';
+    // For starts with and ends with in SQL we have to put the wildcard at the opposite end of
+    // the string to the regex symbol!
+    // Anchored at both ends is an exact match, so it takes no wildcard at all.
+    if (!startAnchor) {
+        source = '%' + source;
+    }
+
+    if (!endAnchor) {
+        source = source + '%';
     }
 
     return {source, ignoreCase};

--- a/packages/mongo-knex/test/unit/convertor.test.js
+++ b/packages/mongo-knex/test/unit/convertor.test.js
@@ -176,6 +176,41 @@ describe('Comparison Query Operators', function () {
             .should.eql('select * from `posts` where lower(`posts`.`email`) like \'%gmail.com\' ESCAPE \'*\'');
     });
 
+    // A value can contain the very characters the anchors are written with. Those arrive escaped
+    // — `5\$`, `\^caret` — so the anchors have to be read before the escaping is removed. Read
+    // afterwards, a literal dollar and an end anchor are the same character, and `contains '5$'`
+    // compiles to the same pattern as `endsWith '5'` while selecting different rows.
+    it('treats an escaped $ as part of the value, not an end anchor', function () {
+        runQuery({title: {$regex: /5\$/i}})
+            .should.eql('select * from `posts` where lower(`posts`.`title`) like \'%5$%\' ESCAPE \'*\'');
+    });
+
+    it('can match endswith on a value that itself ends in $', function () {
+        runQuery({title: {$regex: /5\$$/i}})
+            .should.eql('select * from `posts` where lower(`posts`.`title`) like \'%5$\' ESCAPE \'*\'');
+    });
+
+    it('treats an escaped ^ as part of the value, not a start anchor', function () {
+        runQuery({title: {$regex: /\^caret/i}})
+            .should.eql('select * from `posts` where lower(`posts`.`title`) like \'%^caret%\' ESCAPE \'*\'');
+    });
+
+    it('can match startswith on a value that itself starts with ^', function () {
+        runQuery({title: {$regex: /^\^caret/i}})
+            .should.eql('select * from `posts` where lower(`posts`.`title`) like \'^caret%\' ESCAPE \'*\'');
+    });
+
+    it('can match anchored at both ends, which takes no wildcard at all', function () {
+        runQuery({title: {$regex: /^exact$/i}})
+            .should.eql('select * from `posts` where lower(`posts`.`title`) like \'exact\' ESCAPE \'*\'');
+    });
+
+    // The backslash before the `$` is itself escaped, so the `$` after it is still the anchor.
+    it('reads an end anchor that follows a value ending in a backslash', function () {
+        runQuery({title: {$regex: /a\\$/i}})
+            .should.eql('select * from `posts` where lower(`posts`.`title`) like \'%a\\\\\' ESCAPE \'*\'');
+    });
+
     // % and _ don't have a meaning in regexes, but they do in LIKE, so they should be escaped in the resulting query
     it('correctly escapes _ LIKE special character', function () {
         // Get all posts that contain __GHOST_URL__


### PR DESCRIPTION
## Problem

A filter value can contain the very characters a regex uses for its anchors. Searching for a price that ends in a dollar, or a title that starts with a caret, are ordinary things to ask for.

Those characters arrive escaped, to mark them as part of the value rather than as anchors. But the conversion to a LIKE pattern removed that escaping before it looked for the anchors, so by the time it checked, a literal character and an anchor were the same character.

The result changed both the value and the question. Asking for names containing `5$` was answered as if it asked for names ending in `5`: the dollar was dropped and the operator silently became a different one. Asking for names containing `^caret` was answered as if it asked for names starting with `caret`.

Nothing surfaced this. Both filters still returned rows, just the wrong ones, so a saved Ghost segment could quietly change who it was about without anyone seeing an error.

A pattern anchored at both ends was mishandled too. Only one anchor was ever considered, so anchoring both ends left the trailing character sitting in the pattern as a literal and matched almost nothing.

## Solution

Read the anchors before removing the escaping, rather than after. At that point an escaped character is still visibly escaped, so it can be kept as part of the value while a genuine anchor is recognised as one.

A trailing anchor character counts as an anchor only when an even number of backslashes precedes it, so a value that itself ends in a backslash is still told apart from an escaped dollar.

Both anchors are now handled independently, which makes anchoring both ends an exact match with no wildcard on either side.

Six tests cover the cases. Three of them fail without the change: the two values holding a literal anchor character, and the both-ends match. The rest guard the boundaries the parity counting exists for.

Verified against Ghost with the package linked locally: its members filter suite and full integration suite pass, and the two filters above now select the members they name. The behaviour only changes for filters that were already wrong, so there is nothing for a saved filter to have depended on.